### PR TITLE
Issue/35 add warning for uncaught config store changes

### DIFF
--- a/volttron_installer/backend/models.py
+++ b/volttron_installer/backend/models.py
@@ -524,53 +524,53 @@ EKG_Cos,EKG_Cos,1-0,COS Wave,TRUE,0,float,COS wave"""),
             config_store_allowed=True,
             source="services/core/VolttronCentral"
         ),
-        "platform.agent": AgentType(
-            identity="platform.agent",
-            default_config={},
-            default_config_store={
-                # The volttron-central-address, volttron-central-serverkey and
-                # instance-name may be set in the VCP instance configuration file or
-                # or as command line parameters to the VOLTTRON instance.
-                #
-                # The volttron-central-address is either an http address or a tcp
-                # address.  If it is an http address vc must be running at the resolution
-                # of http://ip:port/discovery/.  VCP will use the tcp address and
-                # serverkey in the response payload to connect to the VC agent instance.
-                #
-                # If the specified address is a tcp address then the configuration
-                # must also contain a volttron-central-serverkey.
-                "volttron-central-address": "http://ip<host>:port `or` tcp://ip:port",
+        # "platform.agent": AgentType(
+        #     identity="platform.agent",
+        #     default_config={},
+        #     default_config_store={
+        #         # The volttron-central-address, volttron-central-serverkey and
+        #         # instance-name may be set in the VCP instance configuration file or
+        #         # or as command line parameters to the VOLTTRON instance.
+        #         #
+        #         # The volttron-central-address is either an http address or a tcp
+        #         # address.  If it is an http address vc must be running at the resolution
+        #         # of http://ip:port/discovery/.  VCP will use the tcp address and
+        #         # serverkey in the response payload to connect to the VC agent instance.
+        #         #
+        #         # If the specified address is a tcp address then the configuration
+        #         # must also contain a volttron-central-serverkey.
+        #         "volttron-central-address": "http://ip<host>:port `or` tcp://ip:port",
 
-                # The serverkey of the VC agent's instance.
-                "volttron-central-serverkey": "VC agent's instance serverkey",
+        #         # The serverkey of the VC agent's instance.
+        #         "volttron-central-serverkey": "VC agent's instance serverkey",
 
-                # interval at which VCP will attempt to connect to the VC agent's
-                # instance when a disconnection occurs.
-                "volttron-central-reconnect-interval": 5,
+        #         # interval at which VCP will attempt to connect to the VC agent's
+        #         # instance when a disconnection occurs.
+        #         "volttron-central-reconnect-interval": 5,
 
-                # The name of instance to be sent to volttron central for displaying
-                # on the interface.
-                "instance-name": "name of instances (VC agent's instance ip address as default)",
+        #         # The name of instance to be sent to volttron central for displaying
+        #         # on the interface.
+        #         "instance-name": "name of instances (VC agent's instance ip address as default)",
 
-                # VCP will publish health statistics of the instance at a specified
-                # interval.
-                "stats-publish-interval": 30,
+        #         # VCP will publish health statistics of the instance at a specified
+        #         # interval.
+        #         "stats-publish-interval": 30,
 
-                # The VCP provides a topic/replace mapping for the platform.  It is
-                # available via rpc function so that sensitive information won't be
-                # published through forwarding.
-                #
-                # The topic-replace-map is used to search/replace all of the topics
-                # published from ForwardHistorians and other agents that connect with
-                # external instances.
-                "topic-replace-map": {
-                    "from": "to",
-                    "from1": "to1"
-                }
-            },
-            config_store_allowed=True,
-            source="services/core/VolttronCentralPlatform"
-        ),
+        #         # The VCP provides a topic/replace mapping for the platform.  It is
+        #         # available via rpc function so that sensitive information won't be
+        #         # published through forwarding.
+        #         #
+        #         # The topic-replace-map is used to search/replace all of the topics
+        #         # published from ForwardHistorians and other agents that connect with
+        #         # external instances.
+        #         "topic-replace-map": {
+        #             "from": "to",
+        #             "from1": "to1"
+        #         }
+        #     },
+        #     config_store_allowed=True,
+        #     source="services/core/VolttronCentralPlatform"
+        # ),
         "weatheragent": AgentType(
             identity="weatheragent",
             default_config={

--- a/volttron_installer/model_views.py
+++ b/volttron_installer/model_views.py
@@ -80,7 +80,7 @@ class ConfigStoreEntryModelView(rx.Base):
         return {
             "path": self.path,
             "data_type": self.data_type,
-            "value": self.value,
+            "value": str(self.value),
             "component_id": self.component_id,
             "csv_variants": self.csv_variants 
         }

--- a/volttron_installer/pages/agent_config_page.py
+++ b/volttron_installer/pages/agent_config_page.py
@@ -1035,20 +1035,26 @@ def agent_draft() -> rx.Component:
                     rx.fragment(
                         rx.divider(),
                         rx.text("No Valid Config Store Entries Detected..."),
-                        rx.cond(
-                            AgentConfigState.uncaught_configs.length() != 0,
-                            rx.container(
-                                rx.hstack(
-                                    rx.icon(
-                                        "triangle-alert"
-                                    ),
-                                    rx.text("At least one invalid config not yet considered"),
-                                    spacing="3"
-                                ),
-                                background_color="#FFA726",
-                                border_radius=".75rem"
-                            )
-                        )
+                    )
+                ),
+                rx.divider(),
+                rx.cond(
+                    AgentConfigState.num_of_new_invalid_configs > 0,
+                    rx.container(
+                        rx.hstack(
+                            rx.icon(
+                                "triangle-alert"
+                            ),
+                            # Proper grammar
+                            rx.cond(
+                                AgentConfigState.num_of_new_invalid_configs==1,
+                                rx.text(f"1 new and unsaved config not yet considered"),
+                                rx.text(f"{AgentConfigState.num_of_new_invalid_configs} new and unsaved configs not yet considered")
+                            ),
+                            spacing="3"
+                        ),
+                        background_color="#FFA726",
+                        border_radius=".75rem"
                     )
                 ),
                 justify="center",

--- a/volttron_installer/pages/agent_config_page.py
+++ b/volttron_installer/pages/agent_config_page.py
@@ -961,7 +961,7 @@ def agent_draft() -> rx.Component:
                                 rx.divider(),
                                 # Checking if our config is uncaught
                                 rx.cond(
-                                    AgentConfigState.uncaught_configs.contains(config.path),
+                                    AgentConfigState.changed_configs_list.contains(config.component_id),
                                     rx.container(
                                         rx.hstack(
                                             rx.icon(

--- a/volttron_installer/pages/agent_config_page.py
+++ b/volttron_installer/pages/agent_config_page.py
@@ -959,6 +959,22 @@ def agent_draft() -> rx.Component:
                             AgentConfigState.committed_configs,
                             lambda config: rx.vstack(
                                 rx.divider(),
+                                # Checking if our config is uncaught
+                                rx.cond(
+                                    AgentConfigState.uncaught_configs.contains(config.path),
+                                    rx.container(
+                                        rx.hstack(
+                                            rx.icon(
+                                                "triangle-alert"
+                                            ),
+                                            rx.text("This config has uncaught changes"),
+                                            spacing="3"
+                                        ),
+                                        background_color="#FFA726",
+                                        border_radius=".75rem"
+                                    )
+                                ),
+                                # rest of the component
                                 form_entry.form_entry(
                                     "Path",
                                     rx.code_block(

--- a/volttron_installer/pages/agent_config_page.py
+++ b/volttron_installer/pages/agent_config_page.py
@@ -679,7 +679,7 @@ def agent_config_page() -> rx.Component:
                                             ),
                                             tooltip=rx.cond(
                                                 AgentConfigState.changed_configs_list.contains(config.component_id),
-                                                "Config store entry has been changed",
+                                                "Config store entry is uncaught",
                                                 ""
                                             ),
                                         )

--- a/volttron_installer/pages/agent_config_page.py
+++ b/volttron_installer/pages/agent_config_page.py
@@ -1034,7 +1034,21 @@ def agent_draft() -> rx.Component:
                     ),
                     rx.fragment(
                         rx.divider(),
-                        rx.text("No Valid Config Store Entries Detected...")
+                        rx.text("No Valid Config Store Entries Detected..."),
+                        rx.cond(
+                            AgentConfigState.uncaught_configs.length() != 0,
+                            rx.container(
+                                rx.hstack(
+                                    rx.icon(
+                                        "triangle-alert"
+                                    ),
+                                    rx.text("At least one invalid config not yet considered"),
+                                    spacing="3"
+                                ),
+                                background_color="#FFA726",
+                                border_radius=".75rem"
+                            )
+                        )
                     )
                 ),
                 justify="center",

--- a/volttron_installer/pages/agent_config_page.py
+++ b/volttron_installer/pages/agent_config_page.py
@@ -679,7 +679,7 @@ def agent_config_page() -> rx.Component:
                                             ),
                                             tooltip=rx.cond(
                                                 AgentConfigState.changed_configs_list.contains(config.component_id),
-                                                "Config store entry is uncaught",
+                                                "Config store entry has unsaved changes",
                                                 ""
                                             ),
                                         )
@@ -967,7 +967,7 @@ def agent_draft() -> rx.Component:
                                             rx.icon(
                                                 "triangle-alert"
                                             ),
-                                            rx.text("This config has uncaught changes"),
+                                            rx.text("This config has unsaved changes"),
                                             spacing="3"
                                         ),
                                         background_color="#FFA726",
@@ -1034,7 +1034,7 @@ def agent_draft() -> rx.Component:
                     ),
                     rx.fragment(
                         rx.divider(),
-                        rx.text("No Valid Config Store Entries Detected..."),
+                        rx.text("No Valid Config Store Entries."),
                     )
                 ),
                 rx.divider(),

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -1045,11 +1045,6 @@ class AgentConfigState(rx.State):
                 logger.debug(f"this is the validity map: {valid_map}")
                 config.valid = valid
                 config.changed = config.dict() != config.safe_entry
-                # this shows the "changed" field as we update the config entry
-                # logger.debug(f"we are checking the {field} field")
-                # logger.debug(f"is changed?: {config.changed}")
-                # logger.debug(f"manually checking dict: {config.dict()}")
-                # logger.debug(f"manually checking safe_entry: {config.safe_entry}")
                 if id is not None:
                     yield rx.set_value(id, value)
                 break

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -847,7 +847,6 @@ class AgentConfigState(rx.State):
     selected_component_id: str = ""
     draft_visible: bool = False
     
-
     # Vars
     # this being named agent details doesn't make sense to be honest
     @rx.var
@@ -979,6 +978,13 @@ class AgentConfigState(rx.State):
         return (len(self.working_agent.config_store) > 0 and 
                 any(not config.uncommitted for config in self.working_agent.config_store))
 
+    @rx.var
+    def uncaught_configs(self) -> list[str]:
+        return [
+                config.safe_entry["path"] for config in self.working_agent.config_store if config.changed
+            ]
+
+    # Events
     @rx.event
     async def hydrate_working_agent(self):
         """Initialize working agent from platform state"""
@@ -991,7 +997,6 @@ class AgentConfigState(rx.State):
                 self.working_agent = agent
                 break
 
-    # Events
     @rx.event
     def flip_draft_visibility(self):
         self.draft_visible = not self.draft_visible

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -945,10 +945,8 @@ class AgentConfigState(rx.State):
                 any(not config.uncommitted for config in self.working_agent.config_store))
 
     @rx.var
-    def uncaught_configs(self) -> list[str]:
-        return [
-                config.safe_entry["path"] for config in self.working_agent.config_store if config.changed
-            ]
+    def num_of_new_invalid_configs(self) -> int:
+        return len([config.path for config in self.working_agent.config_store if config.uncommitted]) 
     # ======== End of config validation vars =========
 
 

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -925,7 +925,7 @@ class AgentConfigState(rx.State):
     @rx.var
     def changed_configs_list(self) -> list[str]:
         """returns a list of component ids for the config store entries that have been changed"""
-        return list(config.component_id for config in self.working_agent.config_store if config.dict() != config.safe_entry)
+        return list(config.component_id for config in self.working_agent.config_store if config.dict() != config.safe_entry or config.safe_entry["path"] == "")
 
     # ======== End of config validation vars =========
 


### PR DESCRIPTION
**Referencing #35.**
This PR creates a way to see if configs are uncaught (changed from their previous safe entry) and displays a warning to the user on the agent draft modal. The user can also see if they have any new and unsaved configs that have not yet been considered.

**Issues outside the scope of this issue**
When first clicking on the fake.csv entry under the platform.driver agent, the config store entry gets flagged as uncaught. This is likely due to some way the agent gets added from the listed agent catalog into the users added agents.

**To see what im talking about**
1.  route to platform/new
2. under agent configuration under the instance configuration accordian, add the platform.driver agent to your added agents
3. route to the platform.driver agent
4. go to the config store and click edit on fake.csv
5. observe

**Additional Improvements outside the scope of this issue**
We could very easily make a way to click on the warning notification, and bring the user back to the agent's config store tab and automatically set the troubling config store entry in focus. This would require having the tab index within either the AgentModelView (not ideal) or within the AgentConfigPageState--hence why all of this refactoring would leave this enhancement outside the scope of this issue.