### PR TITLE
Issue/37 make thin endpoint wrappers wrap individual endpoints

### DIFF
--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -1066,7 +1066,7 @@ class AgentConfigState(rx.State):
         # dealing with file uploads
         current_file = files[0]
         upload_data = await current_file.read()
-        outfile = (rx.get_upload_dir() / current_file.filename)
+        outfile = (rx.get_upload_dir() / current_file.name)
         
         with outfile.open("wb") as file_object:
             file_object.write(upload_data)
@@ -1074,13 +1074,13 @@ class AgentConfigState(rx.State):
         result: str = ""
         file_type: str = ""
 
-        if current_file.filename.endswith('.json'):
+        if current_file.name.endswith('.json'):
             with open(outfile, 'r') as file_object:
                 data = json.load(file_object)
                 file_type = "JSON"
                 result = json.dumps(data, indent=4)
 
-        elif current_file.filename.endswith('.csv'):
+        elif current_file.name.endswith('.csv'):
             with open(outfile, 'r') as file_object:
                 reader = csv.reader(file_object)
                 output = io.StringIO()
@@ -1117,24 +1117,24 @@ class AgentConfigState(rx.State):
         logger.debug("agent config store entry was uploaded")
         yield AgentConfigState.set_component_id(new_config_entry.component_id)
         yield rx.toast.success("Config store entry uploaded successfully")
-        delete_file.delete_file(current_file.filename)
+        delete_file.delete_file(current_file.name)
 
     @rx.event
     async def handle_agent_config_upload(self, files: list[rx.UploadFile]):
         file = files[0]
         upload_data = await file.read()
-        outfile = (rx.get_upload_dir() / file.filename)
+        outfile = (rx.get_upload_dir() / file.name)
         
         with outfile.open("wb") as file_object:
             file_object.write(upload_data)
 
         result: str = ""
 
-        if file.filename.endswith('.json'):
+        if file.name.endswith('.json'):
             with open(outfile, 'r') as file_object:
                 data = json.load(file_object)
                 result = json.dumps(data, indent=4)
-        elif file.filename.endswith('.yaml') or file.filename.endswith('.yml'):
+        elif file.name.endswith('.yaml') or file.name.endswith('.yml'):
             with open(outfile, 'r') as file_object:
                 data = yaml.safe_load(file_object)
                 result = yaml.dump(data, sort_keys=False, default_flow_style=False)
@@ -1145,7 +1145,7 @@ class AgentConfigState(rx.State):
         agent = self.working_agent
         agent.config = result
         yield rx.set_value("agent_config_field", result)
-        delete_file.delete_file(file.filename)
+        delete_file.delete_file(file.name)
     
     @rx.event
     def create_blank_config_entry(self):

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -7,12 +7,7 @@ from .utils.conversion_methods import json_string_to_csv_string, csv_string_to_j
 from .utils.validate_content import check_json, check_csv, check_path, check_yaml, check_regular_expression
 from .utils.create_csv_string import create_csv_string, create_and_validate_csv_string
 from .navigation.state import NavigationState
-from .backend.models import AgentType, HostEntry, PlatformConfig, PlatformDefinition, ConfigStoreEntry, AgentDefinition
-from .backend.endpoints import get_all_platforms, create_platform, \
-    CreatePlatformRequest, CreateOrUpdateHostEntryRequest, add_host, \
-    get_agent_catalog, get_hosts, update_platform, get_inventory_service, \
-    get_platform_service, deploy_platform, \
-    get_ansible_service
+from .backend.models import AgentType, HostEntry, PlatformConfig, PlatformDefinition, ConfigStoreEntry, AgentDefinition, CreatePlatformRequest, CreateOrUpdateHostEntryRequest
 from .utils.create_component_uid import generate_unique_uid
 from .utils.conversion_methods import csv_string_to_usable_dict
 from .utils.validate_content import check_json
@@ -33,10 +28,6 @@ from .thin_endpoint_wrappers import (
 from .thin_endpoint_wrappers import *
 import string, random, json, csv, yaml, re, io
 from copy import deepcopy
-
-
-
-
 
 class AppState(rx.State):
     """The app state."""
@@ -67,11 +58,6 @@ class SettingsState(rx.State):
     _data_dir: str = settings.data_dir
 
 async def __agents_off_catalog__() -> list[AgentModelView]:
-    # response = await get_request(f"{API_BASE_URL}{CATALOG_PREFIX}/agents")
-    # data = response.json()
-    # logger.debug(f"this is the data: {data}")
-    # # Construct the catalog from the data.
-    # catalog: Dict[str, AgentType] = {item["identity"]: AgentType(**item) for item in data}
     catalog: dict[str, AgentType] = await get_agent_catalog()
     agent_list: list[AgentModelView] = []
 
@@ -114,7 +100,6 @@ async def __agents_off_catalog__() -> list[AgentModelView]:
     return agent_list
 
 async def __instances_from_api__() -> dict[str, Instance]:
-    # logger.debug(f"backend url: {rx.config}")
     platforms: list[PlatformDefinition] = await get_all_platforms()
     hosts: list[HostEntry] = await get_hosts()
     host_by_id: dict[str, HostEntry] = {}
@@ -142,9 +127,6 @@ async def __instances_from_api__() -> dict[str, Instance]:
             volttron_home=working_host_entry.volttron_home,
         )
 
-        # platform_status = await get_platform_status(
-        #     get_request("http://localhost:8000/api/platforms/status", p.config.instance_name)
-        #     )
         instance = {
             p.config.instance_name: Instance(
                 host=host,
@@ -199,7 +181,6 @@ async def __instances_from_api__() -> dict[str, Instance]:
                 if config.data_type == "CSV":
                     usable_csv = csv_string_to_usable_dict(config.value)
                     config.csv_variants["Custom"] = usable_csv
-                    # logger.debug(f"Loaded usable CSV for config {config.path} inside agent {agent.identity}: {usable_csv}")
             # After going through the agent's config store and assigning the safe entries,
             # we can now assign the agent's safe_agent
             agent.safe_agent = agent.to_dict()
@@ -596,7 +577,6 @@ class PlatformPageState(rx.State):
 
         working_platform.safe_host_entry = working_platform.host.to_dict()
         working_platform.uncaught = False
-        # logger.debug(f"getting the host id: {working_platform.safe_host_entry['id']}")
         
         # Create base platform
         base_platform_request = CreatePlatformRequest(
@@ -623,9 +603,6 @@ class PlatformPageState(rx.State):
         )
 
         logger.debug(f"this is the uid copy: {uid_copy}")
-        # # Logging
-        # logger.debug(f"Final base platform_request: {base_platform_request}")
-        # logger.debug(f"this is my base platform_request: {base_platform_request}")
         if working_platform.platform.config.instance_name in [p.config.instance_name for p in all_platforms]:
             logger.debug("yes we have committed this already")
             await update_platform(
@@ -638,7 +615,6 @@ class PlatformPageState(rx.State):
         host_request = working_platform.host.to_dict()
         host_request["ansible_port"] = int(host_request["ansible_port"])
         request = CreateOrUpdateHostEntryRequest(**host_request)
-        # logger.debug(f"this is the request: {request}")
         
         logger.debug(f"this is the uid copy: {uid_copy}")
         await add_host(request)
@@ -696,14 +672,11 @@ class PlatformPageState(rx.State):
     def check_instance_uncaught(self, working_platform: Instance) -> bool:
         uncaught: bool = False
         # check if host details are changed
-        # logger.debug(f"I am checking host now..")
         if working_platform.host.to_dict() != working_platform.safe_host_entry:
-            # logger.debug(f"Host is uncaught")
             uncaught = True
 
         # check if platform details are changed but skip the agents field as we will handle that separately
         if {k: v for k, v in working_platform.platform.to_dict().items() if k != 'agents'} != {k: v for k, v in working_platform.platform.safe_platform.items() if k != 'agents'}:
-            # logger.debug(f"Platform is uncaught")
             uncaught = True
 
         # check if we added some new uncaught agents
@@ -714,10 +687,6 @@ class PlatformPageState(rx.State):
                 # we can break out of this because we just needed to find at least one brand new uncaught agent
                 # to render the platform as uncaught
                 break
-
-        # if working_platform.platform.to_dict() != working_platform.platform.safe_platform:
-        #     # logger.debug(f"Platform is uncaught")
-        #     uncaught = True
         
         return uncaught
 
@@ -803,7 +772,6 @@ class PlatformPageState(rx.State):
         
         new_name = working_platform.platform.config.instance_name
         existing_names=[p.platform.safe_platform["config"]["instance_name"] for p in self.in_file_platforms if p.new_instance == False and self.current_uid != p.platform.safe_platform["config"]["instance_name"]]
-        # logger.debug(f"Checking if '{new_name}' exists in: {existing_names}")
 
         # Check to see if our instance is taken already:
         # Seeing if our instance name is inside a list of already registered instance names...

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -17,6 +17,7 @@ from .utils.create_component_uid import generate_unique_uid
 from .utils.conversion_methods import csv_string_to_usable_dict
 from .utils.validate_content import check_json
 from .utils.prettify import prettify_json
+from .utils import delete_file
 from loguru import logger
 from .model_views import HostEntryModelView, PlatformModelView, AgentModelView, ConfigStoreEntryModelView, PlatformConfigModelView
 from .thin_endpoint_wrappers import *
@@ -1116,6 +1117,7 @@ class AgentConfigState(rx.State):
         logger.debug("agent config store entry was uploaded")
         yield AgentConfigState.set_component_id(new_config_entry.component_id)
         yield rx.toast.success("Config store entry uploaded successfully")
+        delete_file.delete_file(current_file.filename)
 
     @rx.event
     async def handle_agent_config_upload(self, files: list[rx.UploadFile]):
@@ -1143,6 +1145,7 @@ class AgentConfigState(rx.State):
         agent = self.working_agent
         agent.config = result
         yield rx.set_value("agent_config_field", result)
+        delete_file.delete_file(file.filename)
     
     @rx.event
     def create_blank_config_entry(self):

--- a/volttron_installer/thin_endpoint_wrappers/__init__.py
+++ b/volttron_installer/thin_endpoint_wrappers/__init__.py
@@ -1,7 +1,6 @@
 import httpx, asyncio
 from typing import Any, Optional, TypeVar, Type, Union, List, Dict
 
-from volttron_installer.backend.endpoints import ping_resolvable_host
 from ..backend.models import AgentType, HostEntry, PlatformDefinition, \
     CreatePlatformRequest, CreateOrUpdateHostEntryRequest, ReachableResponse, \
     PlatformDeploymentStatus, CreateAgentRequest
@@ -151,29 +150,29 @@ async def ping_resolvable_host(host_id: str) -> ReachableResponse:
 
 # PUT requests
 async def update_platform(platform_id: str, platform: CreatePlatformRequest):
-    await put_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/{platform_id}", data=dict(id=platform_id, platform=platform))
+    await put_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/{platform_id}", data=platform.model_dump())
 
 async def update_agent(platform_id: str, agent_id: str, agent: CreateAgentRequest):
-    await put_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/{platform_id}/agents/{agent_id}", data=dict(agent=agent))
+    await put_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/{platform_id}/agents/{agent_id}", data=agent.model_dump())
 
 # POST requests
 async def create_platform(platform: CreatePlatformRequest):
-    await post_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/", data=dict(platform=platform))
+    await post_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/", data=platform.model_dump())
 
 async def deploy_platform(platform_id: str):
     await post_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/deploy/{platform_id}")
 
 async def add_host(host: CreateOrUpdateHostEntryRequest):
-    await post_request(f"{API_BASE_URL}{HOSTS_PREFIX}/", data=dict(host_entry=host))
+    await post_request(f"{API_BASE_URL}{HOSTS_PREFIX}/", data=host.model_dump())
 
 async def start_platform(platform_id: str):
-    await post_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/start_platform", data=dict(platform_id=platform_id))
+    await post_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/start_platform", data=platform_id)
 
 async def stop_platform(platform_id: str):
-    await post_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/stop_platform", data=dict(platform_id=platform_id))
+    await post_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/stop_platform", data=platform_id)
 
 async def create_agent(platform_id: str, agent: CreateAgentRequest):
-    await post_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/{platform_id}/agents", data=dict(agent=agent))
+    await post_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/{platform_id}/agents", data=agent.model_dump())
 
 # DELETE requests
 async def delete_platform(platform_id: str):

--- a/volttron_installer/utils/delete_file.py
+++ b/volttron_installer/utils/delete_file.py
@@ -1,0 +1,13 @@
+import reflex as rx
+from loguru import logger
+import os 
+
+def delete_file(file_name: str) -> None:
+    uploads_dir = rx.get_upload_dir()
+    file_path = os.path.join(uploads_dir, file_name)
+    if os.path.exists(file_path):
+        logger.debug(f"Deleting the file {file_name} from {uploads_dir}.")
+        os.remove(file_path)
+    else:
+        logger.debug(f"The file {file_name} does not exist.")
+    return

--- a/volttron_installer/utils/delete_file.py
+++ b/volttron_installer/utils/delete_file.py
@@ -6,7 +6,6 @@ def delete_file(file_name: str) -> None:
     uploads_dir = rx.get_upload_dir()
     file_path = os.path.join(uploads_dir, file_name)
     if os.path.exists(file_path):
-        logger.debug(f"Deleting the file {file_name} from {uploads_dir}.")
         os.remove(file_path)
     else:
         logger.debug(f"The file {file_name} does not exist.")


### PR DESCRIPTION
Fixes: #37 . Created a set of thin endpoint wrappers for nearly all endpoints excluding `get_tasks` and `task_status` backend endpoints--as it's unclear what we want them to be so to future proof it, we'll leave them alone. 

**Features**
Created a function decorator that mainly concerns the get methods, which takes in the model class we require and outputs the original output from the backend's endpoints. 

Closes #37