### PR TITLE
Issue/51 clickable warning banners within the agent draft

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,82 @@
+FROM python:3.10-slim
+
+# Set shell to bash
+SHELL ["/bin/bash", "-c"]
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install required packages for VOLTTRON dependencies and development tools
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    jq \
+    sudo \
+    vim \
+    wget \
+    unzip \
+    libffi-dev \
+    libssl-dev \
+    procps \
+    lsb-release \
+    bash \
+    openssh-client \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user with sudo access
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# Setup git for PR handling
+RUN apt-get update && apt-get install -y \
+    gh \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure git global settings
+RUN git config --system pull.rebase false
+RUN git config --system core.autocrlf input
+
+# Add a script to help with PR testing
+COPY ./test-pr.sh /usr/local/bin/test-pr
+RUN chmod +x /usr/local/bin/test-pr
+
+# Install Python development tools
+RUN pip install --no-cache-dir \
+    pytest \
+    pylint \
+    flake8 \
+    black \
+    mypy \
+    pytest-cov
+
+# Add user's local bin to PATH to avoid warnings about scripts not being on PATH
+ENV PATH="/home/$USERNAME/.local/bin:$PATH"
+
+# Create .bashrc if it doesn't exist and add PATH
+RUN touch /home/$USERNAME/.bashrc && \
+    echo 'export PATH=$PATH:/home/'$USERNAME'/.local/bin' >> /home/$USERNAME/.bashrc && \
+    chown $USERNAME:$USERNAME /home/$USERNAME/.bashrc
+
+# Create .ssh directory with correct permissions (will be mounted over)
+RUN mkdir -p /home/$USERNAME/.ssh && \
+    chown -R $USERNAME:$USERNAME /home/$USERNAME/.ssh && \
+    chmod 700 /home/$USERNAME/.ssh
+
+# Switch back to dialog for any ad-hoc use of apt
+ENV DEBIAN_FRONTEND=dialog
+
+# Set the default user
+USER $USERNAME
+
+# Add SSH to the known hosts
+RUN mkdir -p ~/.ssh && \
+    ssh-keyscan github.com >> ~/.ssh/known_hosts

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -46,8 +46,10 @@ RUN git config --system pull.rebase false
 RUN git config --system core.autocrlf input
 
 # Add a script to help with PR testing
+# Add scripts to help with PR testing
 COPY ./test-pr.sh /usr/local/bin/test-pr
-RUN chmod +x /usr/local/bin/test-pr
+COPY ./cleanup-pr.sh /usr/local/bin/cleanup-pr
+RUN chmod +x /usr/local/bin/test-pr /usr/local/bin/cleanup-pr
 
 # Install Python development tools
 RUN pip install --no-cache-dir \

--- a/.devcontainer/cleanup-pr.sh
+++ b/.devcontainer/cleanup-pr.sh
@@ -68,4 +68,12 @@ else
     echo "Branch $PR_BRANCH not found, skipping deletion."
 fi
 
+# Pull the latest changes from upstream
+echo "Pulling latest changes from upstream..."
+if git remote | grep -q "^upstream$"; then
+    git pull upstream develop
+else
+    git pull origin develop
+fi
+
 echo "Cleanup complete. Current branch: $(git branch --show-current)"

--- a/.devcontainer/cleanup-pr.sh
+++ b/.devcontainer/cleanup-pr.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Script to clean up after testing a PR
+# Usage: cleanup-pr [PR-NUMBER]
+# If PR-NUMBER is not provided, it will attempt to find the current test branch
+
+set -e
+
+# Function to extract PR number from branch name
+function extract_pr_number() {
+    local branch_name=$1
+    if [[ $branch_name =~ ^pr-([0-9]+)-test$ ]]; then
+        echo "${BASH_REMATCH[1]}"
+        return 0
+    fi
+    return 1
+}
+
+# Get current branch
+CURRENT_BRANCH=$(git branch --show-current)
+
+# If PR number is provided as argument, use it
+if [ -n "$1" ]; then
+    PR_NUMBER=$1
+    BRANCH="pr-$PR_NUMBER-test"
+    PR_BRANCH="pr-$PR_NUMBER"
+else
+    # Try to extract PR number from current branch
+    if PR_NUMBER=$(extract_pr_number "$CURRENT_BRANCH"); then
+        BRANCH="$CURRENT_BRANCH"
+        PR_BRANCH="pr-$PR_NUMBER"
+    else
+        echo "Error: Not on a PR test branch and no PR number provided."
+        echo "Usage: cleanup-pr [PR-NUMBER]"
+        echo "Current branch: $CURRENT_BRANCH"
+        exit 1
+    fi
+fi
+
+echo "Cleaning up PR #$PR_NUMBER (branches: $BRANCH and $PR_BRANCH)"
+
+# Check if we need to switch branches
+if [ "$CURRENT_BRANCH" != "develop" ] && [ "$CURRENT_BRANCH" == "$BRANCH" ]; then
+    echo "Switching to develop branch..."
+    git checkout develop
+fi
+
+# Make sure we're on develop before deleting branches
+if [ "$(git branch --show-current)" != "develop" ]; then
+    git checkout develop
+fi
+
+# Check if branches exist before trying to delete them
+PR_TEST_EXISTS=$(git branch | grep -q " $BRANCH$" && echo "yes" || echo "no")
+PR_BRANCH_EXISTS=$(git branch | grep -q " $PR_BRANCH$" && echo "yes" || echo "no")
+
+if [ "$PR_TEST_EXISTS" == "yes" ]; then
+    echo "Deleting branch $BRANCH..."
+    git branch -D "$BRANCH"
+else
+    echo "Branch $BRANCH not found, skipping deletion."
+fi
+
+if [ "$PR_BRANCH_EXISTS" == "yes" ]; then
+    echo "Deleting branch $PR_BRANCH..."
+    git branch -D "$PR_BRANCH"
+else
+    echo "Branch $PR_BRANCH not found, skipping deletion."
+fi
+
+echo "Cleanup complete. Current branch: $(git branch --show-current)"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,48 @@
+{
+  "name": "VOLTTRON Installer",
+  "dockerFile": "Dockerfile",
+  "runArgs": [
+    "--cap-add=SYS_PTRACE", 
+    "--security-opt", 
+    "seccomp=unconfined"
+  ],
+  
+  "mounts": [
+    "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
+  ],
+  
+  "settings": {
+    "python.defaultInterpreterPath": "/usr/local/bin/python",
+    "python.linting.enabled": true,
+    "python.linting.pylintEnabled": true,
+    "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+    "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+    "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+    "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+    "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+    "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+    "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+    "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+    "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+    "python.testing.pytestEnabled": true,
+    "terminal.integrated.defaultProfile.linux": "bash"
+  },
+  
+  "extensions": [
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "github.vscode-pull-request-github",
+    "ms-azuretools.vscode-docker",
+    "visualstudioexptteam.vscodeintellicode"
+  ],
+  
+  "postCreateCommand": "pip install -r requirements.txt && pip install -e .",
+  
+  "remoteUser": "vscode",
+  
+  "features": {
+    "github-cli": "latest"
+  },
+
+  "postStartCommand": "chmod 700 /home/vscode/.ssh && chmod 600 /home/vscode/.ssh/id_rsa /home/vscode/.ssh/id_rsa.pub || true"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,35 +11,38 @@
     "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
   ],
   
-  "settings": {
-    "python.defaultInterpreterPath": "/usr/local/bin/python",
-    "python.linting.enabled": true,
-    "python.linting.pylintEnabled": true,
-    "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
-    "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
-    "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
-    "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-    "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
-    "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-    "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
-    "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-    "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
-    "python.testing.pytestEnabled": true,
-    "terminal.integrated.defaultProfile.linux": "bash"
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.linting.enabled": true,
+        "python.linting.pylintEnabled": true,
+        "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+        "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+        "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+        "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+        "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+        "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+        "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+        "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+        "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+        "python.testing.pytestEnabled": true,
+      "terminal.integrated.defaultProfile.linux": "bash"
+      },
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "github.vscode-pull-request-github",
+        "ms-azuretools.vscode-docker",
+        "visualstudioexptteam.vscodeintellicode"
+      ]
+    }
   },
-  
-  "extensions": [
-    "ms-python.python",
-    "ms-python.vscode-pylance",
-    "github.vscode-pull-request-github",
-    "ms-azuretools.vscode-docker",
-    "visualstudioexptteam.vscodeintellicode"
-  ],
-  
+
   "postCreateCommand": "pip install -r requirements.txt && pip install -e .",
-  
+
   "remoteUser": "vscode",
-  
+
   "features": {
     "github-cli": "latest"
   },

--- a/.devcontainer/test-pr.sh
+++ b/.devcontainer/test-pr.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Script to help test PRs for volttron-installer
+# Usage: test-pr [PR-NUMBER]
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Usage: test-pr [PR-NUMBER]"
+    exit 1
+fi
+
+PR_NUMBER=$1
+REPO="VOLTTRON/volttron-installer"
+BRANCH="pr-$PR_NUMBER-test"
+
+# Check if we're already in a git repo
+if [ ! -d ".git" ]; then
+    echo "Not in a git repository. Please run this from the root of the volttron-installer repo."
+    exit 1
+fi
+
+# Check for proper SSH setup
+if [ ! -f ~/.ssh/id_rsa ]; then
+    echo "SSH key not found. Checking if HTTPS should be used instead..."
+    
+    # Check if origin is using SSH
+    CURRENT_URL=$(git remote get-url origin)
+    if [[ $CURRENT_URL == git@* ]]; then
+        echo "SSH key not found, but remote uses SSH. Consider using HTTPS or adding SSH keys to the container."
+        echo "To convert to HTTPS, run: git remote set-url origin https://github.com/$REPO.git"
+        exit 1
+    fi
+else
+    # Ensure SSH key has correct permissions
+    chmod 600 ~/.ssh/id_rsa
+    echo "SSH key found with proper permissions."
+fi
+
+# Check for upstream remote, add if missing
+if ! git remote | grep -q "^upstream$"; then
+    echo "Adding upstream remote..."
+    git remote add upstream git@github.com:$REPO.git
+fi
+
+# Make sure we're on develop and up to date
+echo "Fetching latest develop branch..."
+git checkout develop
+git fetch upstream
+git pull upstream develop
+
+# Create a new branch for testing the PR
+echo "Creating branch $BRANCH for testing..."
+git checkout -b $BRANCH
+
+# Fetch the PR
+echo "Fetching PR #$PR_NUMBER..."
+git fetch upstream pull/$PR_NUMBER/head:pr-$PR_NUMBER
+
+# Merge the PR into our test branch
+echo "Merging PR into test branch..."
+git merge pr-$PR_NUMBER
+
+echo ""
+echo "PR $PR_NUMBER has been merged into branch $BRANCH for testing."
+echo "You can now run 'pip install -r requirements.txt && pip install -e .' to update dependencies."
+echo "When done, you can run 'git checkout develop && git branch -D $BRANCH pr-$PR_NUMBER' to clean up."

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 __pycache__/
 *.db
 assets/external/
-
+.devcontainer/.env
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/LICENSE
+++ b/LICENSE
@@ -1,28 +1,216 @@
-BSD 3-Clause License
+Copyright 2025 Battelle Memorial Institute
 
-Copyright (c) 2023, VOLTTRON
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy
+of the License at
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+    http://www.apache.org/licenses/LICENSE-2.0
 
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
 
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
+                                  Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,80 +1,147 @@
-# Eclipse VOLTRON Platform Installer
+# VOLTTRON Installer
 
-## Developer Quick Start
+The VOLTTRON Installer is a tool designed to simplify the installation and configuration of the VOLTTRON platform, an open-source distributed control system platform for integrating with building systems and devices.
 
-1. Clone the repository
-2. Create a python 3.10+ virtual environment inside the volttron-installer directory
-3. Activate the environment
-4. Execute ```pip install -r requirements.txt``` from the volttron-installer directory
-5. Execute ```uvicorn volttron_installer.__main__:app --reload --port 8000
-6. Open browser to [https://localhost:8000](https://localhost:8000)
+## Overview
 
-If using visual studio code, a launch.json file has been created.  Instead of step 5 one can
-launch the application using the debugger for `launch uvicorn application`.
+The VOLTTRON Installer provides:
+- Easy installation of the core VOLTTRON platform
+- Automated configuration of various platform components
+- Support for both development and production deployments
+- Integration with building systems and IoT devices
 
-## Brief Overview
+## System Requirements
 
-On launch, the user is greeted to an `Overview` page with tabs. These tabs house several key pages like `Platforms`- which displays all the platforms registered, `Agent Setup`- a page where a user can setup an agent, `Hosts`- a page displaying all registered pages and where you can edit and deploy new pages, and `Config Store Manager`- a page where you can edit, add, and delete configs that should serve as defaults when registering a config to an agent.
+### Base System Requirements
 
-On the top right is a button to add a blank slate of a platform. Clicking on this button produces a tile in the `Platforms` tab, this tile routes to the platforms specific page where 2 more tabs are present. `Platform Config` - a page where you can configure a platform under a host and bind agents, and `Agent Config` - a tab where you can select an agent, configure that agent with custom JSON or scroll down to an agents specific `Config Store Manager` where you can edit agent specific drivers. Once you have properly set up an Platform, the deploy platform button on the header should be available to you and you should be able to deploy your platform
+When running on bare metal, ensure your system has:
 
-## Technical Overview
+- **Python**: 3.10 or above
+- **System Dependencies**:
+  ```bash
+  sudo apt update
+  sudo apt install -y build-essential libffi-dev libssl-dev git python3-dev python3-venv unzip
+  ```
 
-Routing happens in the `__init__.py` file where it displays our `home.py`/Overview page. Our dynamically routered pages also are managed in this `__init__.py` file. Dynamic routes are created once a `PlatformTile` instance is created in the home page.
+## Installation Options
 
-Each program tile instance houses their own view and each of these views are their own objects. These objects communicate through a shared `Platform` instance with `ObjectCommunicator` acting as their event bus allowing for a shared state and efficient way of writing and reading from a central, what i deem a, __pseudo database__. You can see how it works under `components/platform_components/platform.py` and inspecting how `platform_tabs/agent_config.py` or `platform_tabs/platform_config.py` use the shared instance with something like ctrl + F __self.platform__.
+### Option 1: Direct Installation with Pip
 
-## Noticable Flaws Within Code Base
+1. **Create a Virtual Environment** (recommended)
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
 
-There is lots of confusing structure design going on. For example, in `platform_tile.py`, the whole page platform routing and display happens in this file even though the name suggests it would be more or less a component. This file also is the constructor for the program view's tabs. Taking a look at the section in `ProgramTile` instance where the `PlatformConfig` instance is created, you see that we pass in containers and text fields. This doesn't really make sense because we can still pass everything up into the main shared instance of `Program`. And to write to the shared instance we would simply have something like `self.program.address = textfield.value`. Everything still works but realistically the only thing that needs to be passed is the shared instance.
+2. **Install VOLTTRON Installer**
+   ```bash
+   pip install git+https://github.com/VOLTTRON/volttron-installer.git@develop
+   ```
 
-The whole `components/platformcomponents` dir is just so weird... platform.py isnt even a component its so much more and i dont even know why `agent.py` is even in `componenets/` either i messed up a little bit
+3. **Run the Installer**
+   ```bash
+   volttron-installer
+   ```
 
-There is also a lot of redundant files which in my opinion clutter up the workspace. Files like `config_manager.py` and `platform_manager.py` under `views` have no use.
+### Option 2: Development Installation
 
-The main overview tabs withing the `views` dir, `global_config_store.py`, `agent_setup.py`, and `host_tabs.py` all share really similar code. Their forms are really similarly coded and it would be nice to break it apart. But they work nonetheless.
+1. **Clone the Repository**
+   ```bash
+   git clone https://github.com/VOLTTRON/volttron-installer.git
+   cd volttron-installer
+   ```
 
-## Developer checklist
+2. **Create and Activate Virtual Environment**
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
 
-- [x] Have a way to update all UI components with any additions or edits to the `global_hosts`, `global_drivers`, or `global_agents` variables under `/modules/global_configs` | One way I've thought about going about this was to create some sort of observer instance for each of these variables and have each platform subscribe to a signal like "update_global_ui" and once this observer instance sees changes, publishes the "update_global_ui" signal. These signals could all be possible with the `class ObjectCommunicator` in `platform.py` most likely by instantiating one instance of Object Communicator and passing it into the `Platform` object as well as the observer instance object we've been talking about.
+3. **Install in Development Mode**
+   ```bash
+   pip install -r requirements.txt
+   pip install -e .
+   ```
 
-- [ ] inside a `PlatformTile` instance, clicking on an agent in agent config should bring up their agent specific configuration store underneath.
+4. **Run the Installer**
+   ```bash
+   volttron-installer
+   ```
 
-- [ ] inside a `PlatformTile` instance, we need to deem what are the suitable requirements for a platform to be deployed and be able to deploy a platform and write that instance to `platforms.json`
+### Option 3: Using VS Code Dev Containers
 
-- [ ] In the overview page, `config_store_manager` we need to add a text box or something to edit the configuration of a driver.
+The repository includes a Dev Container configuration that allows you to develop and test the project in a consistent environment.
 
-- [ ] In `Agent Setup` tab in overview, when clicking on the modal in the form, we need to have a dropdown with all the available drivers that are registered within the `Config Store Manager`. From there, we can edit the driver to the agent's specific needs. Inside `views/agent_setup.py` and under the `Agent` class, there should be a new attribute like `driver_custom_config` and it should be pretty easy to differentiate whether or not it is a csv or json config. with this config we could write to the agents.json file with its custom driver configs.
+#### Prerequisites
 
-## issues
+- [VS Code](https://code.visualstudio.com/download)
+- [Docker](https://docs.docker.com/get-docker/)
+- [VS Code Remote - Containers Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
 
-- when you populate either the hosts or agent setup in the respective global pages in Overview, once you decide
-to take a look at a platform's view and go back to the host or agents page in Overview, their tiles disappear.
+#### Steps
 
-<!-- # volttron-installer
-### Installing Prerequisites
-1. Ensure that Python version 3.10[^1] is installed by running `python3.10 --version`
-   - If Python 3.10 is not installed, add the deadsnakes PPA by running `sudo add-apt-repository ppa:deadsnakes/ppa`
-   - Run `sudo apt update` to refresh the cache.
-   - Install Python 3.10 by running `sudo apt install python3.10`
-   - Validate that Python 3.10 was installed by running `python3.10 --version`
-2. Ensure that curl is installed on the system by running `curl --version`
-   - If curl is not installed, run `sudo apt install curl` to install it.
-### Running the Script
-1. Run the command `python3 <(curl -sSL https://raw.githubusercontent.com/VOLTTRON/volttron-installer/develop/web.py)`
-   - Installs the ansible, git, pexpect, pip and python3.10-venv packages if they are not already installed
-   - Creates and activates a virtual environment in the directory where the script was ran
-   - Installs the volttron-ansible collection
-   - Prompts user to choose the amount of instances they want installed (maximum of 5)
-   - Starts a web server and opens the default browser, pointing to 'http://localhost:8080'
-2. Navigating the Web Page - 1 instance
-   - Enter password then click 'Install Base Requirements' to install what is needed for volttron
-   - After the base requirements have been installed, click 'Create Instance' to create and run the instance
-   - After installation, pick whatever services are needed for the instance and click 'Install Services'
-   - Start and stop buttons for the instance are show on the bottom of the page
-3. Navigating the Web Page - Multiple Instances
-   - Pick what services are needed for each instance and click 'Configure Instance'
-   - Navigate to the bottom of the page to enter your password, then click 'Install All Instances'
-   - Start and stop buttons are provided under 'Configure Instance' for each instance
-[^1]: Any version of Python greater than 3.10 will work -->
+1. **Clone the Repository**
+   ```bash
+   git clone https://github.com/VOLTTRON/volttron-installer.git
+   cd volttron-installer
+   ```
 
+2. **Open in VS Code**
+   ```bash
+   code .
+   ```
+
+3. **Reopen in Container**
+   When prompted by VS Code, click "Reopen in Container" or use the command palette (F1) and select "Remote-Containers: Reopen in Container".
+
+4. **Testing Pull Requests**
+   Once the container is running, you can test pull requests using the included script:
+   ```bash
+   test-pr [PR-NUMBER]
+   ```
+
+5. **Clean Up After Testing**
+   When finished testing, clean up using:
+   ```bash
+   cleanup-pr
+   ```
+
+## Usage
+
+After installation, run the VOLTTRON Installer:
+
+```bash
+volttron-installer
+```
+
+Follow the interactive prompts to configure your VOLTTRON installation.
+
+## Configuration Options
+
+The installer supports various configuration options:
+
+- Platform installation path
+- Message bus configuration
+- Agent selection and configuration
+- Security settings
+- Historian database configuration
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+Copyright 2025 Battelle Memorial Institute
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy
+of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+    
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.

--- a/volttron_installer/components/custom_fields/csv_field.py
+++ b/volttron_installer/components/custom_fields/csv_field.py
@@ -191,7 +191,7 @@ def craft_table_cell(content: str, header: str = None, index: int = None, row_id
     )
 
 @base_component_wrapper
-def csv_table(width=r"100%", height="100%", **props):
+def csv_table(height="100%", **props):
     return rx.table.root(
         rx.table.header(
             rx.table.row(
@@ -222,7 +222,6 @@ def csv_table(width=r"100%", height="100%", **props):
                 )
             )
         ),
-        width=width,
         height=height,
         **props
     )
@@ -330,7 +329,7 @@ def remove_column_dialog(disabled: bool = False):
         )
     )
 
-def csv_data_field(disabled: bool = False, **props):
+def csv_data_field(disabled: bool = False, table_style={}, table_width="100%", **props):
     return rx.cond(
         CSVDataState.is_hydrated, 
         rx.flex(
@@ -344,24 +343,24 @@ def csv_data_field(disabled: bool = False, **props):
                 )
             ),
             rx.flex(
-                rx.el.div(
-                    csv_table(disabled=disabled, **props),
-                    class_name="config_template_config_container"
-                ),
+                # rx.el.div(
+                    csv_table(disabled=disabled, width=table_width, style=table_style),
+                    # style={}
+                # ),
                 rx.flex(
                     add_column_dialog(disabled=disabled),
                     rx.divider(),
                     remove_column_dialog(disabled=disabled),
                     direction="column",
-                    spacing="4"
+                    spacing="4",
                 ),
                 direction="row",
                 spacing="4",
-                width=r"calc(100% - 2rem)",
-                max_width="100%"
+                width="100%",
             ),
             spacing="6",
-            direction="column"
+            direction="column",
+            **props
         ),
         rx.spinner(height="100vh")
     )

--- a/volttron_installer/components/custom_fields/csv_field.py
+++ b/volttron_installer/components/custom_fields/csv_field.py
@@ -343,10 +343,7 @@ def csv_data_field(disabled: bool = False, table_style={}, table_width="100%", *
                 )
             ),
             rx.flex(
-                # rx.el.div(
-                    csv_table(disabled=disabled, width=table_width, style=table_style),
-                    # style={}
-                # ),
+                csv_table(disabled=disabled, width=table_width, style=table_style),
                 rx.flex(
                     add_column_dialog(disabled=disabled),
                     rx.divider(),

--- a/volttron_installer/model_views.py
+++ b/volttron_installer/model_views.py
@@ -98,6 +98,8 @@ class AgentModelView(rx.Base):
 
     in_file: bool = False
 
+    # Fields that handle UI actions and functionality
+    selected_agent_config_tab: str = "1"
     selected_config_component_id: str = ""
     routing_id: str = ""
 

--- a/volttron_installer/models.py
+++ b/volttron_installer/models.py
@@ -14,6 +14,7 @@ class Instance(rx.Base):
     uncaught: bool = False
     valid: bool = False    
 
+    # UI vars
     web_checked: bool = False
     advanced_expanded: bool = False
     agent_configuration_expanded: bool = False

--- a/volttron_installer/pages/agent_config_page.py
+++ b/volttron_installer/pages/agent_config_page.py
@@ -841,7 +841,9 @@ def agent_config_page() -> rx.Component:
                         ),
                         value="2"
                     ),
-                    default_value="1"
+                    default_value="1",
+                    on_change=lambda v: AgentConfigState.change_agent_config_tab(v),
+                    value=AgentConfigState.selected_tab
                 ),
                 direction="column",
                 spacing="4",
@@ -850,83 +852,83 @@ def agent_config_page() -> rx.Component:
         ),
         # Skeleton stuff
         rx.vstack(
-        # Header
-        rx.hstack(
+            # Header
+            rx.hstack(
+                rx.skeleton(
+                    rx.box(),
+                    height="3rem",
+                    width="5rem",
+                    radius="5rem",
+                    loading=True,
+                ),
+                rx.skeleton(
+                    rx.box(),
+                    height="3rem",
+                    width="12rem",
+                    radius="5rem",
+                    loading=True,
+                ),
+                rx.skeleton(
+                    rx.box(),
+                    height="2.5rem",
+                    width="5rem",
+                    radius="5rem",
+                    loading=True,
+                ),
+                spacing="4",
+                align="center",
+            ),
+            # Tabs divider
             rx.skeleton(
                 rx.box(),
-                height="3rem",
-                width="5rem",
-                radius="5rem",
+                width="100%",
+                height="15px",
                 loading=True,
             ),
-            rx.skeleton(
-                rx.box(),
-                height="3rem",
-                width="12rem",
-                radius="5rem",
-                loading=True,
+            # Fields
+            rx.vstack(
+                rx.skeleton(
+                    rx.box(),
+                    width="4.5rem",
+                    height="1.5rem",
+                ),
+                rx.skeleton(
+                    rx.box(),
+                    width="14rem",
+                    height="2rem",
+                ),
+                spacing="4"
             ),
-            rx.skeleton(
-                rx.box(),
-                height="2.5rem",
-                width="5rem",
-                radius="5rem",
-                loading=True,
+            rx.vstack(
+                rx.skeleton(
+                    rx.box(),
+                    width="4.5rem",
+                    height="1.5rem",
+                ),
+                rx.skeleton(
+                    rx.box(),
+                    width="14rem",
+                    height="2rem",
+                ),
+                spacing="4"
             ),
-            spacing="4",
-            align="center",
-        ),
-        # Tabs divider
-        rx.skeleton(
-            rx.box(),
-            width="100%",
-            height="15px",
-            loading=True,
-        ),
-        # Fields
-        rx.vstack(
-            rx.skeleton(
-                rx.box(),
-                width="4.5rem",
-                height="1.5rem",
+            rx.vstack(
+                rx.skeleton(
+                    rx.box(),
+                    width="4.5rem",
+                    height="1.5rem",
+                ),
+                rx.skeleton(
+                    rx.box(),
+                    width="40rem",
+                    height="25rem",
+                ),
+                spacing="4"
             ),
-            rx.skeleton(
-                rx.box(),
-                width="14rem",
-                height="2rem",
-            ),
-            spacing="4"
-        ),
-        rx.vstack(
-            rx.skeleton(
-                rx.box(),
-                width="4.5rem",
-                height="1.5rem",
-            ),
-            rx.skeleton(
-                rx.box(),
-                width="14rem",
-                height="2rem",
-            ),
-            spacing="4"
-        ),
-        rx.vstack(
-            rx.skeleton(
-                rx.box(),
-                width="4.5rem",
-                height="1.5rem",
-            ),
-            rx.skeleton(
-                rx.box(),
-                width="40rem",
-                height="25rem",
-            ),
-            spacing="4"
-        ),
-        spacing="6",
-        padding="1rem",
+            spacing="6",
+            padding="1rem",
+        )
     )
-)
 
 def agent_draft() -> rx.Component:
     return rx.cond(AgentConfigState.is_hydrated, rx.dialog.root(
@@ -981,7 +983,9 @@ def agent_draft() -> rx.Component:
                                             ),
                                             rx.text("This config has unsaved changes"),
                                             spacing="3"
-                                        ),
+                                        ),                            
+                                        cursor="pointer",
+                                        on_click=lambda: AgentConfigState.handle_unsaved_config_banner_click(config.component_id),
                                         background_color="#FFA726",
                                         border_radius=".75rem"
                                     )

--- a/volttron_installer/pages/agent_config_page.py
+++ b/volttron_installer/pages/agent_config_page.py
@@ -767,14 +767,34 @@ def agent_config_page() -> rx.Component:
                                                                         )
                                                                     ),
                                                                     rx.vstack(
-                                                                        csv_field.csv_data_field(),
+                                                                        # rx.box(
+                                                                        csv_field.csv_data_field(
+                                                                            # style={
+                                                                            #     "width" : "calc(calc(100% - max(10vw, 30px)) - 20px)",
+                                                                            #     "overflow-x" : "auto",
+                                                                            # },
+                                                                            # table_style={
+                                                                            #     "width": "60vw",
+                                                                            # },
+                                                                            table_width=rx.breakpoints(
+                                                                                {
+                                                                                    "0px" : "40vw",
+                                                                                    "1200px" : "60vw"
+
+                                                                                }
+                                                                            )
+                                                                        ),
+                                                                        #     style={
+                                                                        #         "width": "inherit",
+                                                                        #     }
+                                                                        # ),
                                                                         rx.cond(
                                                                             AgentConfigState.check_csv_validity == False,
                                                                             rx.text(
                                                                                 "Invalid CSV variant detected",
                                                                                 color_scheme="red"
                                                                             )
-                                                                        )
+                                                                        ),
                                                                     )
                                                                 ),
                                                             ),
@@ -821,13 +841,15 @@ def agent_config_page() -> rx.Component:
                                 # border="1px solid white",
                                 border_radius=".5rem",
                                 padding="1rem",
-                                flex="1"
+                                flex="1",
+                                width="100%"
                             ),
                             align="start",
                             spacing="6",
                             direction="row",
                             padding_top="1rem",
-                            width="100%"
+                            id="this bro foo"
+                            # width="clamp(15rem, 20vw, 100%)"
                         ),
                         value="2"
                     ),

--- a/volttron_installer/pages/agent_config_page.py
+++ b/volttron_installer/pages/agent_config_page.py
@@ -928,6 +928,7 @@ def agent_draft() -> rx.Component:
                     "Identity",
                     rx.code_block(
                         AgentConfigState.working_agent.identity,
+                        style={"width": "clamp(15rem, 70vw, 100%)", "overflow_x": "auto"},
                         # disabled=True
                     )
                 ),
@@ -935,6 +936,7 @@ def agent_draft() -> rx.Component:
                     "Source",
                     rx.code_block(
                         AgentConfigState.working_agent.source,
+                        style={"width": "clamp(15rem, 70vw, 100%)", "overflow_x": "auto"},
                         # disabled=True
                     )
                 ),
@@ -947,7 +949,7 @@ def agent_draft() -> rx.Component:
                         ),
                         scrollbars="horizontal",
                         type="auto",
-                        style={"width":"30rem"}
+                        style={"width": "clamp(15rem, 70vw, 100%)", "overflow_x": "auto"},
                     ),
                 ),
                 rx.cond(
@@ -978,21 +980,9 @@ def agent_draft() -> rx.Component:
                                 form_entry.form_entry(
                                     "Path",
                                     rx.code_block(
-                                        config.path
+                                        config.path,
+                                        style={"width": "clamp(15rem, 70vw, 100%)", "overflow_x": "auto"},
                                     )
-                                    # rx.scroll_area(
-                                    #     rx.code_block(
-                                    #         config.path,
-                                    #         # language="json",
-                                    #     ),
-                                    #     scrollbars="horizontal",
-                                    #     type="auto",
-                                    #     style={"width":"30rem"}
-                                    # ),
-                                    # rx.input(
-                                    #     value=config.path,
-                                    #     disabled=True
-                                    # )
                                 ),
                                 form_entry.form_entry(
                                     "Data Type",
@@ -1014,7 +1004,7 @@ def agent_draft() -> rx.Component:
                                             ),
                                             scrollbars="horizontal",
                                             type="auto",
-                                            style={"width":"30rem"}
+                                            style={"width": "clamp(15rem, 70vw, 100%)", "overflow_x": "auto"},
                                         ),
                                         rx.box(
                                             rx.scroll_area(
@@ -1024,7 +1014,7 @@ def agent_draft() -> rx.Component:
                                                 ),
                                                 scrollbars="horizontal",
                                                 type="auto",
-                                                style={"width":"30rem"}
+                                                style={"width": "clamp(15rem, 70vw, 90rem)", "overflow_x": "auto"},
                                             ),
                                         )
                                     )
@@ -1077,6 +1067,8 @@ def agent_draft() -> rx.Component:
                 ),
                 justify="between"
             ),
+            max_width="100rem",
+            width="clamp(20rem, 80vw, 100rem)",
         ),
         open=AgentConfigState.draft_visible
     ))

--- a/volttron_installer/pages/agent_config_page.py
+++ b/volttron_installer/pages/agent_config_page.py
@@ -767,15 +767,7 @@ def agent_config_page() -> rx.Component:
                                                                         )
                                                                     ),
                                                                     rx.vstack(
-                                                                        # rx.box(
                                                                         csv_field.csv_data_field(
-                                                                            # style={
-                                                                            #     "width" : "calc(calc(100% - max(10vw, 30px)) - 20px)",
-                                                                            #     "overflow-x" : "auto",
-                                                                            # },
-                                                                            # table_style={
-                                                                            #     "width": "60vw",
-                                                                            # },
                                                                             table_width=rx.breakpoints(
                                                                                 {
                                                                                     "0px" : "40vw",
@@ -784,10 +776,6 @@ def agent_config_page() -> rx.Component:
                                                                                 }
                                                                             )
                                                                         ),
-                                                                        #     style={
-                                                                        #         "width": "inherit",
-                                                                        #     }
-                                                                        # ),
                                                                         rx.cond(
                                                                             AgentConfigState.check_csv_validity == False,
                                                                             rx.text(

--- a/volttron_installer/pages/agent_config_page.py
+++ b/volttron_installer/pages/agent_config_page.py
@@ -605,7 +605,6 @@ def agent_config_page() -> rx.Component:
                             False,
                             True
                         )
-                        # on_click=lambda: AgentConfigState.save_agent_config()
                     ),
                     spacing="6",
                     align="center"
@@ -672,7 +671,6 @@ def agent_config_page() -> rx.Component:
                                             #TODO, i would like to create a system to check if the config is changed or not, apparently we cant index the 
                                             # dict which is annoying....
                                             class_name=rx.cond(
-                                                # True,
                                                 AgentConfigState.changed_configs_list.contains(config.component_id),
                                                 "agent_config_tile uncommitted",
                                                 "agent_config_tile"
@@ -690,10 +688,8 @@ def agent_config_page() -> rx.Component:
                                     spacing="4",
                                     justify="start",
                                 ),
-                                # border="1px solid white",
                                 border_radius=".5rem",
                                 padding="1rem",
-                                # flex="1"
                             ),
                             rx.flex(
                                 rx.flex(
@@ -826,7 +822,6 @@ def agent_config_page() -> rx.Component:
                                     align="start",
                                     spacing="6",
                                 ),
-                                # border="1px solid white",
                                 border_radius=".5rem",
                                 padding="1rem",
                                 flex="1",
@@ -836,8 +831,6 @@ def agent_config_page() -> rx.Component:
                             spacing="6",
                             direction="row",
                             padding_top="1rem",
-                            id="this bro foo"
-                            # width="clamp(15rem, 20vw, 100%)"
                         ),
                         value="2"
                     ),
@@ -949,7 +942,6 @@ def agent_draft() -> rx.Component:
                     rx.code_block(
                         AgentConfigState.working_agent.source,
                         style={"width": "clamp(15rem, 70vw, 100%)", "overflow_x": "auto"},
-                        # disabled=True
                     )
                 ),
                 form_entry.form_entry(

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -1066,7 +1066,7 @@ class AgentConfigState(rx.State):
         # dealing with file uploads
         current_file = files[0]
         upload_data = await current_file.read()
-        outfile = (rx.get_upload_dir() / current_file.filename)
+        outfile = (rx.get_upload_dir() / current_file.name)
         
         with outfile.open("wb") as file_object:
             file_object.write(upload_data)
@@ -1074,13 +1074,13 @@ class AgentConfigState(rx.State):
         result: str = ""
         file_type: str = ""
 
-        if current_file.filename.endswith('.json'):
+        if current_file.name.endswith('.json'):
             with open(outfile, 'r') as file_object:
                 data = json.load(file_object)
                 file_type = "JSON"
                 result = json.dumps(data, indent=4)
 
-        elif current_file.filename.endswith('.csv'):
+        elif current_file.name.endswith('.csv'):
             with open(outfile, 'r') as file_object:
                 reader = csv.reader(file_object)
                 output = io.StringIO()
@@ -1117,24 +1117,24 @@ class AgentConfigState(rx.State):
         logger.debug("agent config store entry was uploaded")
         yield AgentConfigState.set_component_id(new_config_entry.component_id)
         yield rx.toast.success("Config store entry uploaded successfully")
-        delete_file.delete_file(current_file.filename)
+        delete_file.delete_file(current_file.name)
 
     @rx.event
     async def handle_agent_config_upload(self, files: list[rx.UploadFile]):
         file = files[0]
         upload_data = await file.read()
-        outfile = (rx.get_upload_dir() / file.filename)
+        outfile = (rx.get_upload_dir() / file.name)
         
         with outfile.open("wb") as file_object:
             file_object.write(upload_data)
 
         result: str = ""
 
-        if file.filename.endswith('.json'):
+        if file.name.endswith('.json'):
             with open(outfile, 'r') as file_object:
                 data = json.load(file_object)
                 result = json.dumps(data, indent=4)
-        elif file.filename.endswith('.yaml') or file.filename.endswith('.yml'):
+        elif file.name.endswith('.yaml') or file.name.endswith('.yml'):
             with open(outfile, 'r') as file_object:
                 data = yaml.safe_load(file_object)
                 result = yaml.dump(data, sort_keys=False, default_flow_style=False)
@@ -1145,7 +1145,7 @@ class AgentConfigState(rx.State):
         agent = self.working_agent
         agent.config = result
         yield rx.set_value("agent_config_field", result)
-        delete_file.delete_file(file.filename)
+        delete_file.delete_file(file.name)
     
     @rx.event
     def create_blank_config_entry(self):

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -7,12 +7,7 @@ from .utils.conversion_methods import json_string_to_csv_string, csv_string_to_j
 from .utils.validate_content import check_json, check_csv, check_path, check_yaml, check_regular_expression
 from .utils.create_csv_string import create_csv_string, create_and_validate_csv_string
 from .navigation.state import NavigationState
-from .backend.models import AgentType, HostEntry, PlatformConfig, PlatformDefinition, ConfigStoreEntry, AgentDefinition
-from .backend.endpoints import get_all_platforms, create_platform, \
-    CreatePlatformRequest, CreateOrUpdateHostEntryRequest, add_host, \
-    get_agent_catalog, get_hosts, update_platform, get_inventory_service, \
-    get_platform_service, deploy_platform, \
-    get_ansible_service
+from .backend.models import AgentType, HostEntry, PlatformConfig, PlatformDefinition, ConfigStoreEntry, AgentDefinition, CreatePlatformRequest, CreateOrUpdateHostEntryRequest
 from .utils.create_component_uid import generate_unique_uid
 from .utils.conversion_methods import csv_string_to_usable_dict
 from .utils.validate_content import check_json
@@ -33,10 +28,6 @@ from .thin_endpoint_wrappers import (
 from .thin_endpoint_wrappers import *
 import string, random, json, csv, yaml, re, io
 from copy import deepcopy
-
-
-
-
 
 class AppState(rx.State):
     """The app state."""
@@ -67,11 +58,6 @@ class SettingsState(rx.State):
     _data_dir: str = settings.data_dir
 
 async def __agents_off_catalog__() -> list[AgentModelView]:
-    # response = await get_request(f"{API_BASE_URL}{CATALOG_PREFIX}/agents")
-    # data = response.json()
-    # logger.debug(f"this is the data: {data}")
-    # # Construct the catalog from the data.
-    # catalog: Dict[str, AgentType] = {item["identity"]: AgentType(**item) for item in data}
     catalog: dict[str, AgentType] = await get_agent_catalog()
     agent_list: list[AgentModelView] = []
 
@@ -114,7 +100,6 @@ async def __agents_off_catalog__() -> list[AgentModelView]:
     return agent_list
 
 async def __instances_from_api__() -> dict[str, Instance]:
-    # logger.debug(f"backend url: {rx.config}")
     platforms: list[PlatformDefinition] = await get_all_platforms()
     hosts: list[HostEntry] = await get_hosts()
     host_by_id: dict[str, HostEntry] = {}
@@ -142,9 +127,6 @@ async def __instances_from_api__() -> dict[str, Instance]:
             volttron_home=working_host_entry.volttron_home,
         )
 
-        # platform_status = await get_platform_status(
-        #     get_request("http://localhost:8000/api/platforms/status", p.config.instance_name)
-        #     )
         instance = {
             p.config.instance_name: Instance(
                 host=host,
@@ -199,7 +181,6 @@ async def __instances_from_api__() -> dict[str, Instance]:
                 if config.data_type == "CSV":
                     usable_csv = csv_string_to_usable_dict(config.value)
                     config.csv_variants["Custom"] = usable_csv
-                    # logger.debug(f"Loaded usable CSV for config {config.path} inside agent {agent.identity}: {usable_csv}")
             # After going through the agent's config store and assigning the safe entries,
             # we can now assign the agent's safe_agent
             agent.safe_agent = agent.to_dict()
@@ -596,7 +577,6 @@ class PlatformPageState(rx.State):
 
         working_platform.safe_host_entry = working_platform.host.to_dict()
         working_platform.uncaught = False
-        # logger.debug(f"getting the host id: {working_platform.safe_host_entry['id']}")
         
         # Create base platform
         base_platform_request = CreatePlatformRequest(
@@ -623,9 +603,6 @@ class PlatformPageState(rx.State):
         )
 
         logger.debug(f"this is the uid copy: {uid_copy}")
-        # # Logging
-        # logger.debug(f"Final base platform_request: {base_platform_request}")
-        # logger.debug(f"this is my base platform_request: {base_platform_request}")
         if working_platform.platform.config.instance_name in [p.config.instance_name for p in all_platforms]:
             logger.debug("yes we have committed this already")
             await update_platform(
@@ -638,7 +615,6 @@ class PlatformPageState(rx.State):
         host_request = working_platform.host.to_dict()
         host_request["ansible_port"] = int(host_request["ansible_port"])
         request = CreateOrUpdateHostEntryRequest(**host_request)
-        # logger.debug(f"this is the request: {request}")
         
         logger.debug(f"this is the uid copy: {uid_copy}")
         await add_host(request)
@@ -696,14 +672,11 @@ class PlatformPageState(rx.State):
     def check_instance_uncaught(self, working_platform: Instance) -> bool:
         uncaught: bool = False
         # check if host details are changed
-        # logger.debug(f"I am checking host now..")
         if working_platform.host.to_dict() != working_platform.safe_host_entry:
-            # logger.debug(f"Host is uncaught")
             uncaught = True
 
         # check if platform details are changed but skip the agents field as we will handle that separately
         if {k: v for k, v in working_platform.platform.to_dict().items() if k != 'agents'} != {k: v for k, v in working_platform.platform.safe_platform.items() if k != 'agents'}:
-            # logger.debug(f"Platform is uncaught")
             uncaught = True
 
         # check if we added some new uncaught agents
@@ -714,10 +687,6 @@ class PlatformPageState(rx.State):
                 # we can break out of this because we just needed to find at least one brand new uncaught agent
                 # to render the platform as uncaught
                 break
-
-        # if working_platform.platform.to_dict() != working_platform.platform.safe_platform:
-        #     # logger.debug(f"Platform is uncaught")
-        #     uncaught = True
         
         return uncaught
 
@@ -803,7 +772,6 @@ class PlatformPageState(rx.State):
         
         new_name = working_platform.platform.config.instance_name
         existing_names=[p.platform.safe_platform["config"]["instance_name"] for p in self.in_file_platforms if p.new_instance == False and self.current_uid != p.platform.safe_platform["config"]["instance_name"]]
-        # logger.debug(f"Checking if '{new_name}' exists in: {existing_names}")
 
         # Check to see if our instance is taken already:
         # Seeing if our instance name is inside a list of already registered instance names...

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -17,6 +17,7 @@ from .utils.create_component_uid import generate_unique_uid
 from .utils.conversion_methods import csv_string_to_usable_dict
 from .utils.validate_content import check_json
 from .utils.prettify import prettify_json
+from .utils import delete_file
 from loguru import logger
 from .model_views import HostEntryModelView, PlatformModelView, AgentModelView, ConfigStoreEntryModelView, PlatformConfigModelView
 from .thin_endpoint_wrappers import *
@@ -1116,6 +1117,7 @@ class AgentConfigState(rx.State):
         logger.debug("agent config store entry was uploaded")
         yield AgentConfigState.set_component_id(new_config_entry.component_id)
         yield rx.toast.success("Config store entry uploaded successfully")
+        delete_file.delete_file(current_file.filename)
 
     @rx.event
     async def handle_agent_config_upload(self, files: list[rx.UploadFile]):
@@ -1143,6 +1145,7 @@ class AgentConfigState(rx.State):
         agent = self.working_agent
         agent.config = result
         yield rx.set_value("agent_config_field", result)
+        delete_file.delete_file(file.filename)
     
     @rx.event
     def create_blank_config_entry(self):

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -804,6 +804,10 @@ class AgentConfigState(rx.State):
         agent_uid = args.get("agent_uid", "")
         return {"uid": uid, "agent_uid": agent_uid}
 
+    @rx.var
+    def selected_tab(self) -> str:
+        return self.working_agent.selected_agent_config_tab
+
     # ========= state vars to streamline working checking the validity of working config =======
     
     # TODO: implement def config_uncaught var
@@ -945,6 +949,10 @@ class AgentConfigState(rx.State):
                 break
 
     @rx.event
+    def change_agent_config_tab(self, value):
+        self.working_agent.selected_agent_config_tab = value
+
+    @rx.event
     def flip_draft_visibility(self):
         self.draft_visible = not self.draft_visible
         logger.debug(f"ok bro is {self.draft_visible}")
@@ -997,6 +1005,13 @@ class AgentConfigState(rx.State):
                     yield rx.set_value(id, value)
                 break
     
+    @rx.event
+    def handle_unsaved_config_banner_click(self, component_id: str):
+        """Handle click on unsaved config banner to set the selected component id"""
+        self.working_agent.selected_config_component_id = component_id
+        yield AgentConfigState.flip_draft_visibility
+        yield AgentConfigState.change_agent_config_tab("2")
+
     @rx.event
     async def handle_config_store_entry_upload(self, files: list[rx.UploadFile]):
         # dealing with file uploads

--- a/volttron_installer/thin_endpoint_wrappers/__init__.py
+++ b/volttron_installer/thin_endpoint_wrappers/__init__.py
@@ -1,7 +1,6 @@
 import httpx, asyncio
 from typing import Any, Optional, TypeVar, Type, Union, List, Dict
 
-from volttron_installer.backend.endpoints import ping_resolvable_host
 from ..backend.models import AgentType, HostEntry, PlatformDefinition, \
     CreatePlatformRequest, CreateOrUpdateHostEntryRequest, ReachableResponse, \
     PlatformDeploymentStatus, CreateAgentRequest
@@ -151,29 +150,29 @@ async def ping_resolvable_host(host_id: str) -> ReachableResponse:
 
 # PUT requests
 async def update_platform(platform_id: str, platform: CreatePlatformRequest):
-    await put_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/{platform_id}", data=dict(id=platform_id, platform=platform))
+    await put_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/{platform_id}", data=platform.model_dump())
 
 async def update_agent(platform_id: str, agent_id: str, agent: CreateAgentRequest):
-    await put_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/{platform_id}/agents/{agent_id}", data=dict(agent=agent))
+    await put_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/{platform_id}/agents/{agent_id}", data=agent.model_dump())
 
 # POST requests
 async def create_platform(platform: CreatePlatformRequest):
-    await post_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/", data=dict(platform=platform))
+    await post_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/", data=platform.model_dump())
 
 async def deploy_platform(platform_id: str):
     await post_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/deploy/{platform_id}")
 
 async def add_host(host: CreateOrUpdateHostEntryRequest):
-    await post_request(f"{API_BASE_URL}{HOSTS_PREFIX}/", data=dict(host_entry=host))
+    await post_request(f"{API_BASE_URL}{HOSTS_PREFIX}/", data=host.model_dump())
 
 async def start_platform(platform_id: str):
-    await post_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/start_platform", data=dict(platform_id=platform_id))
+    await post_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/start_platform", data=platform_id)
 
 async def stop_platform(platform_id: str):
-    await post_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/stop_platform", data=dict(platform_id=platform_id))
+    await post_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/stop_platform", data=platform_id)
 
 async def create_agent(platform_id: str, agent: CreateAgentRequest):
-    await post_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/{platform_id}/agents", data=dict(agent=agent))
+    await post_request(f"{API_BASE_URL}{PLATFORMS_PREFIX}/{platform_id}/agents", data=agent.model_dump())
 
 # DELETE requests
 async def delete_platform(platform_id: str):

--- a/volttron_installer/utils/delete_file.py
+++ b/volttron_installer/utils/delete_file.py
@@ -1,0 +1,13 @@
+import reflex as rx
+from loguru import logger
+import os 
+
+def delete_file(file_name: str) -> None:
+    uploads_dir = rx.get_upload_dir()
+    file_path = os.path.join(uploads_dir, file_name)
+    if os.path.exists(file_path):
+        logger.debug(f"Deleting the file {file_name} from {uploads_dir}.")
+        os.remove(file_path)
+    else:
+        logger.debug(f"The file {file_name} does not exist.")
+    return

--- a/volttron_installer/utils/delete_file.py
+++ b/volttron_installer/utils/delete_file.py
@@ -6,7 +6,6 @@ def delete_file(file_name: str) -> None:
     uploads_dir = rx.get_upload_dir()
     file_path = os.path.join(uploads_dir, file_name)
     if os.path.exists(file_path):
-        logger.debug(f"Deleting the file {file_name} from {uploads_dir}.")
         os.remove(file_path)
     else:
         logger.debug(f"The file {file_name} does not exist.")


### PR DESCRIPTION
Closes #51 

Creates a selected tab field within the agent view model that the state reads from, and updates the UI accordingly. When the user clicks on the warning banner of a particular config store entry, the agent draft modal is closed, the page is set to the config store entries tab, and the affected config store entry is selected for editing.

The only problem is that we are now setting a lot of UI fields within the view models, but I brought up a work around in #59 