### PR TITLE
issue/59_add_method_to_reset_certain_instance_fields_for_copied_platforms

### DIFF
--- a/volttron_installer/models.py
+++ b/volttron_installer/models.py
@@ -34,3 +34,17 @@ class Instance(rx.Base):
             host_dict["ansible_user"] and \
             host_dict["ansible_host"] != ""
         )
+
+    def refresh_for_copy(self) -> None:
+        """
+        Refresh the instance for copying.
+        """
+        self.new_instance = True
+        self.platform.in_file = False
+        for agent in self.platform.agents.values():
+            agent.in_file = False
+            agent.selected_config_component_id = ""
+            agent.selected_agent_config_tab="1"
+            for config in agent.config_store:
+                config.in_file = False
+                config.selected_cell = ""

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -513,8 +513,7 @@ class PlatformPageState(rx.State):
         uid = self.generate_unique_uid()
         copy_instance = deepcopy(self.platforms[instance_name])
         copy_instance.platform.config.instance_name = uid
-        copy_instance.new_instance = True
-        copy_instance.platform.in_file = False
+        copy_instance.refresh_for_copy()
         self.platforms[uid] = copy_instance
         yield NavigationState.route_to_platform(self.platforms[uid].platform.config.instance_name)
         yield rx.toast.info(f"Platform: {instance_name} has been copied")


### PR DESCRIPTION
Implement a refresh_for_copy method in Instance class and update PlatormPageState to use it when we are copying instances.

This is mainly for consistency, and as we potentially continue to have the UI rely more on the state, this is helpful in staying organized and serves as a definitive place where we should make changes.

Closes #59 