### PR TITLE
BACnet Scan Page Developments

### DIFF
--- a/volttron_installer/backend/endpoints.py
+++ b/volttron_installer/backend/endpoints.py
@@ -551,12 +551,12 @@ async def bacnet_scan_start_proxy(local_device_address: str | None = None) -> di
     except ApiError as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
 
-@bacnet_scan_tool_router.get("/get_windows_host_ip", response_model=dict[str, str])
-async def bacnet_scan_get_windows_host_ip() -> dict[str, str]:
+@bacnet_scan_tool_router.get("/get_host_ip", response_model=dict)
+async def bacnet_scan_get_host_ip() -> dict:
     # OPTIONAL, for WSL2 users
     from .tool_proxy_factory import ApiError
 
-    url=get_api_url.get_api_url("/api/tool_proxy/bacnet_scan_tool/get_windows_host_ip")
+    url=get_api_url.get_api_url("/api/tool_proxy/bacnet_scan_tool/get_host_ip")
     try:
         response = await ToolProxyFactory.request(
             url,

--- a/volttron_installer/backend/endpoints.py
+++ b/volttron_installer/backend/endpoints.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException, Depends, Request
-from typing import Optional
+from typing import Any, Optional
 from ..utils import get_api_url
 import os, asyncio
 
@@ -10,6 +10,8 @@ from volttron_installer.backend.services.platform_service import PlatformService
 from volttron_installer.backend.models import AgentCatalog
 
 from volttron_installer.backend.tool_proxy_factory import ToolProxyFactory
+
+from bacnet_scan_tool.models import ScanResponse, ObjectListNamesResponse
 
 from .models import (
     CreateOrUpdateHostEntryRequest,
@@ -532,8 +534,8 @@ async def bacnet_scan_get_local_ip(target_ip: str = None) -> dict[str, str]:
     except ApiError as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
 
-@bacnet_scan_tool_router.post("/start_proxy", response_model=dict[str, str])
-async def bacnet_scan_start_proxy(local_device_address: str | None = None) -> dict[str, str]:
+@bacnet_scan_tool_router.post("/start_proxy", response_model=dict[str, Any])
+async def bacnet_scan_start_proxy(local_device_address: str | None = None) -> dict[str, Any]:
     from .tool_proxy_factory import ApiError
 
     url=get_api_url.get_api_url("/api/tool_proxy/bacnet_scan_tool/start_proxy")
@@ -565,12 +567,12 @@ async def bacnet_scan_get_windows_host_ip() -> dict[str, str]:
     except ApiError as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
     
-@bacnet_scan_tool_router.post("/bacnet/scan_ip_range", response_model=BACnetScanResults)
-async def bacnet_scan_scan_ip_range(network_str: str) -> dict[str, str]:
+@bacnet_scan_tool_router.post("/bacnet/scan_subnet", response_model=ScanResponse)
+async def bacnet_scan_subnet(network_str: str | None = None) -> dict[str, str]:
     from .tool_proxy_factory import ApiError
 
-    url=get_api_url.get_api_url("/api/tool_proxy/bacnet_scan_tool/bacnet/scan_ip_range")
-    REQUEST={"network_str": network_str}
+    url=get_api_url.get_api_url("/api/tool_proxy/bacnet_scan_tool/bacnet/scan_subnet")
+    REQUEST={"subnet": network_str}
     try:
         response = await ToolProxyFactory.request(
             url,
@@ -579,20 +581,8 @@ async def bacnet_scan_scan_ip_range(network_str: str) -> dict[str, str]:
             timeout=600.0
         )
         data = response.json()
-        return BACnetScanResults(
-            status=data["status"],
-            devices=[
-                BACnetDevice(
-                    pduSource=device["pduSource"],
-                    deviceIdentifier=device["deviceIdentifier"],
-                    maxAPDULengthAccepted=device["maxAPDULengthAccepted"],
-                    segmentationSupported=device["segmentationSupported"],
-                    vendorID=device["vendorID"],
-                    object_name=device["object-name"],
-                    scanned_ip_target=device["scanned_ip_target"],
-                    device_instance=device["device_instance"]
-                ) for device in data["devices"]
-            ]
+        return ScanResponse(
+            **data
         )
     except ApiError as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
@@ -698,8 +688,8 @@ async def bacnet_scan_who_is(
     except ApiError as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
 
-@bacnet_scan_tool_router.post("/stop_proxy", response_model=dict[str, str])
-async def bacnet_scan_stop_proxy() -> dict[str, str]:
+@bacnet_scan_tool_router.post("/stop_proxy", response_model=dict[str, Any])
+async def bacnet_scan_stop_proxy() -> dict[str, Any]:
     from .tool_proxy_factory import ApiError
 
     url=get_api_url.get_api_url("/api/tool_proxy/bacnet_scan_tool/stop_proxy")
@@ -713,3 +703,29 @@ async def bacnet_scan_stop_proxy() -> dict[str, str]:
     except ApiError as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
     
+@bacnet_scan_tool_router.post("/bacnet/read_object_list_names", response_model=ObjectListNamesResponse)
+async def bacnet_scan_read_object_list_names(
+    device_address: str, 
+    device_object_identifier: str,
+    page: int = 1,
+    page_size: int = 100
+) -> ObjectListNamesResponse:
+    from .tool_proxy_factory import ApiError
+
+    url=get_api_url.get_api_url("/api/tool_proxy/bacnet_scan_tool/bacnet/read_object_list_names")
+    REQUEST = {
+        "device_address": device_address,
+        "device_object_identifier": device_object_identifier,
+        "page": page,
+        "page_size": page_size
+    }
+    try:
+        response = await ToolProxyFactory.request(
+            url,
+            "POST",
+            data=REQUEST
+        )
+        data = response.json()
+        return ObjectListNamesResponse(**data)
+    except ApiError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.detail)

--- a/volttron_installer/backend/endpoints.py
+++ b/volttron_installer/backend/endpoints.py
@@ -627,11 +627,12 @@ async def bacnet_scan_write_property(request: BACnetWritePropertyRequest) -> dic
         }
     if request.property_array_index is not None:
         REQUEST["property_array_index"] = request.property_array_index
+    logger.debug(f"this is i, the endpoint, passing in: {REQUEST}")
     try:
         response = await ToolProxyFactory.request(
             url,
             "POST",
-            data=REQUEST
+            params=REQUEST
         )
         data = response.json()
         return data

--- a/volttron_installer/backend/endpoints.py
+++ b/volttron_installer/backend/endpoints.py
@@ -620,10 +620,12 @@ async def bacnet_scan_read_property(request: BACnetReadPropertyRequest) -> dict:
     except ApiError as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
 
-@bacnet_scan_tool_router.post("/write_property", response_model=dict[str, str])
-async def bacnet_scan_write_property(request: BACnetWritePropertyRequest) -> dict[str, str]:
+@bacnet_scan_tool_router.post("/write_property", response_model=dict)
+async def bacnet_scan_write_property(request: BACnetWritePropertyRequest) -> dict:
     from .tool_proxy_factory import ApiError
-
+    from loguru import logger
+    
+    logger.debug(f"this is i, the endpiont getting: {request}")
     url=get_api_url.get_api_url("/api/tool_proxy/bacnet_scan_tool/write_property")
     REQUEST = {
             "device_address": request.device_address,

--- a/volttron_installer/backend/models.py
+++ b/volttron_installer/backend/models.py
@@ -816,3 +816,9 @@ class BACnetWritePropertyRequest(BaseModel):
 class BACnetReadDeviceAllRequest(BaseModel):
     device_address: str
     device_object_identifier: str
+
+class BACnetReadObjectListRequest(BaseModel):
+    device_address: str
+    device_object_identifier: str
+    page: int | None = None
+    page_size: int | None = None

--- a/volttron_installer/backend/tool_manager.py
+++ b/volttron_installer/backend/tool_manager.py
@@ -4,8 +4,8 @@ import subprocess
 import sys
 import threading
 import time
+import socket
 from datetime import datetime
-from pathlib import Path
 from typing import Dict, Optional
 from loguru import logger
 
@@ -44,6 +44,28 @@ class ToolManager:
             logger.debug(f"Tool access recorded: {tool_name} at {datetime.now().strftime('%H:%M:%S')}")
 
     @classmethod
+    def is_port_available(cls, port: int) -> bool:
+        """Check if a port is available to use."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                # Try to bind to the port
+                s.bind(('', port))
+                return True
+            except socket.error:
+                # Port is already in use
+                return False
+    
+    @classmethod
+    def find_available_port(cls, start_port: int = 8001, max_attempts: int = 100) -> int:
+        """Find an available port starting from start_port."""
+        current_port = start_port
+        for _ in range(max_attempts):
+            if cls.is_port_available(current_port):
+                return current_port
+            current_port += 1
+        raise RuntimeError(f"Could not find an available port after {max_attempts} attempts")
+
+    @classmethod
     def _normalize_tool_name(cls, name):
         """Normalize tool names to avoid case/format mismatches"""
         return str(name).lower().replace(" ", "_")
@@ -79,8 +101,16 @@ class ToolManager:
         
         # Assign a port if not specified
         if port is None:
-            port = cls._next_available_port
-            cls._next_available_port += 1
+            # Find an available port instead of just incrementing
+            port = cls.find_available_port(cls._next_available_port)
+            cls._next_available_port = port + 1
+        else:
+            # If specific port is requested, check if it's available
+            if not cls.is_port_available(port):
+                return {
+                    "success": False,
+                    "message": f"Port {port} is already in use by another process"
+                }
         
         # Extract package name from module path
         package_name = module_path.split('.')[0]

--- a/volttron_installer/components/tiles/platform_tile.py
+++ b/volttron_installer/components/tiles/platform_tile.py
@@ -3,14 +3,27 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from ...pages.platform_page import Instance
 
-def platform_tile(platform_uid: str, platform_item: "Instance", **props) -> rx.Component:
+def platform_tile(
+        platform_uid: str, 
+        platform_item: "Instance", 
+        background_color="rgba(145, 145, 145, 0.29)",
+        **props
+    ) -> rx.Component:
     return rx.flex(
-        rx.hstack(
-            rx.text(platform_uid),
-            rx.text(""),
-            justify="between"
+        rx.grid(
+            rx.text(platform_uid, size="2", grid_column="span 2"),
+            # rx.text("Running", size="2"),
+            # rx.text("Off", size="2"),
+            spacing="2",
+            columns="2"
         ),
         direction="column",
-        class_name="platform_tile",
+        background_color=background_color,
+        cursor="pointer",
+        width="9rem",
+        height="9rem",
+        padding=".25rem .75rem",
+        border_radius=".5rem",
+        user_select="none",
         **props
     )

--- a/volttron_installer/model_views.py
+++ b/volttron_installer/model_views.py
@@ -181,6 +181,7 @@ class PlatformModelView(rx.Base):
     
 class BACnetDevicePointModelView(rx.Base):
     device_name: str
+    volttron_point_name: str
     writable: bool
     object_type: str
     present_value: str
@@ -188,14 +189,24 @@ class BACnetDevicePointModelView(rx.Base):
     index: str | int # should really only be an int but who knows
     notes: str
 
+    write_request_target: dict = {}
+
     # UI driven field
     selected: bool = False
     present_value_editing: bool = False
+    volttron_point_name_editing: bool = False
     safe_point: dict = {}
     
+    def set_write_request_target(self, device_address: str, object_identifier: str):
+        self.write_request_target={
+            "device_address": device_address,
+            "object_identifier": object_identifier
+        }
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "device_name": self.device_name,
+            "volttron_point_name": self.volttron_point_name,
             "units": self.units,
             "object_type": self.object_type,
             "present_value": self.present_value,

--- a/volttron_installer/model_views.py
+++ b/volttron_installer/model_views.py
@@ -7,7 +7,13 @@ class ConfigStoreEntryModelView(rx.Base):
     value: str = ""
 
     contains_errors: bool = False
-    safe_entry: dict[str, Any] = {}
+    safe_entry: dict[str, Any] = {
+        "path": "",
+        "data_type": "JSON",
+        "value": "",
+        "component_id": "_",
+        "csv_variants": ""
+    }
     component_id: str = "_"
 
     uncommitted: bool = True
@@ -104,6 +110,8 @@ class AgentModelView(rx.Base):
     routing_id: str = ""
 
     def to_dict(self) -> dict[str, Any]:
+        # from loguru import logger
+        # logger.debug(f"config store: {self.config_store}")
         return {
             "identity": self.identity,
             "source": self.source,

--- a/volttron_installer/model_views.py
+++ b/volttron_installer/model_views.py
@@ -1,5 +1,5 @@
 import reflex as rx
-from typing import Any, Literal
+from typing import Any, Literal, Optional
 
 class ConfigStoreEntryModelView(rx.Base):
     path: str = ""
@@ -192,8 +192,8 @@ class BACnetDevicePointModelView(rx.Base):
     volttron_point_name: str
     writable: bool
     object_type: str
-    present_value: str
-    units: str | int
+    present_value: str | None = ""
+    units: str | int | None = ""
     index: str | int # should really only be an int but who knows
     notes: str
 
@@ -225,15 +225,15 @@ class BACnetDevicePointModelView(rx.Base):
         }
 
 class BACnetDeviceModelView(rx.Base):
-    pduSource: str
+    object_name: str = "" # This will be added later in the scan of a subnet 
     deviceIdentifier: str
-    maxAPDULengthAccepted: int
-    segmentationSupported: str
-    vendorID: int
-    object_name: str
+    maxAPDULengthAccepted: Optional[int] = None
+    segmentationSupported: Optional[str] = None
+    vendorID: Optional[int] = None
     scanned_ip_target: str
     device_instance: int
     points: list[BACnetDevicePointModelView] = []
 
     # UI driven field
     select_all_points: bool = False
+    read_device_all_failed: bool = False

--- a/volttron_installer/model_views.py
+++ b/volttron_installer/model_views.py
@@ -188,6 +188,17 @@ class BACnetDevicePointModelView(rx.Base):
 
     # UI driven field
     selected: bool = False
+    present_value_editing: bool = False
+    safe_point: dict = {}
+    
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "device_name": self.device_name,
+            "writable": self.writable,
+            "present_value": self.present_value,
+            "units": self.units,
+            "notes": self.notes
+        }
 
 class BACnetDeviceModelView(rx.Base):
     pduSource: str

--- a/volttron_installer/model_views.py
+++ b/volttron_installer/model_views.py
@@ -182,6 +182,7 @@ class PlatformModelView(rx.Base):
 class BACnetDevicePointModelView(rx.Base):
     device_name: str
     writable: bool
+    object_type: str
     present_value: str
     units: str | int
     index: str | int # should really only be an int but who knows
@@ -195,9 +196,11 @@ class BACnetDevicePointModelView(rx.Base):
     def to_dict(self) -> dict[str, Any]:
         return {
             "device_name": self.device_name,
-            "writable": self.writable,
-            "present_value": self.present_value,
             "units": self.units,
+            "object_type": self.object_type,
+            "present_value": self.present_value,
+            "writable": self.writable,
+            "index": self.index,
             "notes": self.notes
         }
 

--- a/volttron_installer/model_views.py
+++ b/volttron_installer/model_views.py
@@ -192,6 +192,7 @@ class BACnetDevicePointModelView(rx.Base):
     write_request_target: dict = {}
 
     # UI driven field
+    never_writable: bool = False
     selected: bool = False
     present_value_editing: bool = False
     volttron_point_name_editing: bool = False

--- a/volttron_installer/model_views.py
+++ b/volttron_installer/model_views.py
@@ -192,9 +192,9 @@ class BACnetDevicePointModelView(rx.Base):
     volttron_point_name: str
     writable: bool
     object_type: str
-    present_value: str | None = ""
-    units: str | int | None = ""
-    index: str | int # should really only be an int but who knows
+    present_value: str = ""
+    units: str | int = ""
+    index: str | int # should really only be an int but strings are needed for the ui (text fields)
     notes: str
 
     write_request_target: dict = {}

--- a/volttron_installer/model_views.py
+++ b/volttron_installer/model_views.py
@@ -184,6 +184,7 @@ class BACnetDevicePointModelView(rx.Base):
     writable: bool
     present_value: str
     units: str | int
+    index: str | int # should really only be an int but who knows
     notes: str
 
     # UI driven field

--- a/volttron_installer/models.py
+++ b/volttron_installer/models.py
@@ -96,7 +96,16 @@ class LocalIPModel(rx.Base):
     subnet_mask: str = ""
     cidr: str = ""
 
-class BACnetPointFilters(rx.Base):
+class BACnetPointTableFilter(rx.Base):
+    volttron_point_name: str = ""
+    units: str = ""
+    object_type: str = ""
+    writable: str = ""
+    present_value: str = ""
+    index: str = ""
+    notes: str = ""
+
+class BACnetPointColumnFilters(rx.Base):
     volttron_point_name: bool = True
     units: bool = True
     object_type: bool = True

--- a/volttron_installer/models.py
+++ b/volttron_installer/models.py
@@ -89,7 +89,7 @@ class WritePropertyModel(rx.Model):
     property_array_index: str | int = ""
 
 class WindowsHostIPModel(rx.Base):
-    windows_host_ip: str = "" 
+    address: str = "" 
 
 class LocalIPModel(rx.Base):
     local_ip: str = ""

--- a/volttron_installer/models.py
+++ b/volttron_installer/models.py
@@ -97,6 +97,7 @@ class LocalIPModel(rx.Base):
     cidr: str = ""
 
 class BACnetPointFilters(rx.Base):
+    volttron_point_name: bool = True
     units: bool = True
     object_type: bool = True
     writable: bool = True

--- a/volttron_installer/models.py
+++ b/volttron_installer/models.py
@@ -98,7 +98,13 @@ class LocalIPModel(rx.Base):
 
 class BACnetPointFilters(rx.Base):
     units: bool = True
+    object_type: bool = True
     writable: bool = True
     present_value: bool = True
     index: bool = True
     notes: bool = True
+
+class BACnetObjectType(rx.Base):
+    value: int
+    type_name: str
+    writable: bool

--- a/volttron_installer/models.py
+++ b/volttron_installer/models.py
@@ -95,3 +95,10 @@ class LocalIPModel(rx.Base):
     local_ip: str = ""
     subnet_mask: str = ""
     cidr: str = ""
+
+class BACnetPointFilters(rx.Base):
+    units: bool = True
+    writable: bool = True
+    present_value: bool = True
+    index: bool = True
+    notes: bool = True

--- a/volttron_installer/models.py
+++ b/volttron_installer/models.py
@@ -118,3 +118,9 @@ class BACnetObjectType(rx.Base):
     value: int
     type_name: str
     writable: bool
+
+class BACnetDevicePointScanStatus(rx.Base):
+    object_name: str
+    message: str
+    device_name: str
+    percent_finished: int

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -6,7 +6,7 @@ from ..components.buttons.tile_icon import tile_icon
 from ..layouts import app_layout_sidebar
 from ..model_views import BACnetDeviceModelView, BACnetDevicePointModelView
 
-def filter_badge(text: str, **props) -> rx.Component:
+def filter_badge(text: str, cursor: str = "pointer", **props) -> rx.Component:
     return rx.badge(
         rx.hstack(
             rx.icon("x", size=12),
@@ -16,7 +16,7 @@ def filter_badge(text: str, **props) -> rx.Component:
         ),
         color_scheme="blue",
         variant="surface",
-        cursor="pointer",
+        cursor=cursor,
         size="1",
         **props
     )
@@ -841,6 +841,11 @@ def present_value_cell(point: BACnetDevicePointModelView, index: int) -> rx.Comp
                     rx.button(
                         rx.icon("pencil", size=12),
                         size="1",
+                        disabled=rx.cond(
+                            point.writable,
+                            False,
+                            True
+                        ),
                         on_click=lambda: BacnetScanState.enable_device_point_present_value_edit(index)
                     )
                 )
@@ -938,10 +943,19 @@ def show_device_point(point_tuple: tuple[int, BACnetDevicePointModelView], index
         rx.cond(
             BacnetScanState.point_column_filter.writable,
             rx.table.cell(
-                rx.cond(
+                rx.box(
+                    rx.cond(
                     point.writable,
-                    true_writable_badge(),
-                    false_writable_badge()
+                        true_writable_badge(),
+                        false_writable_badge()
+                    ),
+                    disabled=point.never_writable,
+                    cursor=rx.cond(
+                        point.never_writable,
+                        "not-allowed",
+                        "pointer"
+                    ),
+                    on_click=lambda: BacnetScanState.flip_device_point_writable(index)
                 )
             )
         ),

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -955,20 +955,30 @@ def render() -> rx.Component:
                     rx.cond(
                         ToolState.running_tools.contains("bacnet_scan_tool") == False,
                         rx.fragment(
-                            rx.grid(
-                                rx.skeleton(width="100%"),
-                                rx.skeleton(width="100%"),
-                                spacing="6",
-                                width="100%",
-                                columns={ "base": "1", "md": "2" }
+                            rx.hstack(
+                                rx.hstack(
+                                    rx.skeleton(height="50px", width="50px", border_radius=".5rem"),
+                                    rx.skeleton(height="30px", width="200px", border_radius=".5rem"),
+                                    align="center"
+                                ),
+                                rx.skeleton(height="25px", width="100px", border_radius=".5rem"),
+                                justify="between",
+                                align="center",
+                                width="100%"
                             ),
                             rx.grid(
-                                rx.skeleton(width="100%"),
-                                rx.skeleton(width="100%"),
-                                rx.skeleton(width="100%"),
+                                rx.skeleton(width="100%", height="250px", border_radius=".5rem"),
+                                rx.skeleton(width="100%", height="250px", border_radius=".5rem"),
+                                rx.skeleton(width="100%", height="250px", border_radius=".5rem"),
                                 spacing="6",
                                 width="100%",
-                                columns={ "base": "1", "md": "3" }      
+                                columns={ "base": "1", "md": "3" }
+                            ),
+                            rx.grid(
+                                rx.skeleton(width="100%", height="1300px", border_radius=".5rem"),
+                                spacing="6",
+                                width="100%",
+                                columns="1"
                             )
                         ),
                         rx.fragment(

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -403,7 +403,7 @@ def scan_for_devices_card():
         ),
         rx.box(  # CardContent
             rx.vstack(
-                rx.text("Network Range (CIDR)", as_="label", html_for="local-ip"),
+                rx.text("Subnet Range (CIDR)", as_="label", html_for="local-ip"),
                 rx.input(
                     id="network_str",
                     placeholder="e.g. 192.168.1.0/24",
@@ -642,7 +642,7 @@ def show_device(device: BACnetDeviceModelView, index: int) -> rx.Component:
                     rx.vstack(
                         rx.vstack(
                             rx.text("Device Points", size="1", weight="bold"),
-                            rx.text(f"Select points to export or configure to a platform", size="1", color="gray"),
+                            rx.text(f"Select points to export to CSV or create a registry config file", size="1", color="gray"),
                             rx.text(f"{BacnetScanState.selected_points.length()} points selected", size="1", color="gray"),
                             spacing="1",
                             margin_bottom="12px"

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -682,14 +682,20 @@ def add_to_registry_config_file_dialog() -> rx.Component:
         # Selecting Platforms Dialog
         rx.dialog.root(
             rx.dialog.content(
-                rx.dialog.title("Select Platforms"),
-                rx.dialog.description("Are you sure you want to add to the registry config file?"),
+                rx.dialog.title("Select a Platform"),
+                rx.dialog.description("Select a platform to add the registry config file to."),
                 rx.hstack(
                     rx.foreach(
                         PlatformPageState.in_file_platforms,
                         lambda platform: platform_tile.platform_tile(
                             platform.platform.config.instance_name,
-                            platform
+                            platform,
+                            background_color=rx.cond(
+                                BacnetScanState.selected_platform_uid == platform.platform.config.instance_name,
+                                "#44C0ED",
+                                "rgba(145, 145, 145, 0.29)"
+                            ),
+                            on_click=lambda: BacnetScanState.select_platform_for_registry_config(platform.platform.config.instance_name)
                         )
                     ),
                     wrap="wrap",
@@ -711,6 +717,11 @@ def add_to_registry_config_file_dialog() -> rx.Component:
                         color_scheme="green",
                         variant="soft",
                         size="2",
+                        disabled=rx.cond(
+                            BacnetScanState.selected_platform_uid == "",
+                            True,
+                            False
+                        ),
                         on_click=BacnetScanState.close_dialogs,  # Or your confirm logic
                     ),
                     width="100%",

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -132,6 +132,42 @@ def false_writable_badge() -> rx.Component:
         border_radius=".5rem"
     )
 
+def present_value_cell(point: BACnetDevicePointModelView, index: int) -> rx.Component:
+    return rx.table.cell(
+        rx.hstack(
+            rx.cond(
+                point.present_value_editing,
+                rx.fragment(
+                    rx.text_field(
+                        value=point.present_value,
+                        size="1",
+                        on_change=lambda v: BacnetScanState.handle_present_value_edit(index, v)
+                    ),
+                    rx.button(
+                        rx.icon("save", size=12),
+                        size="1",
+                        on_click=lambda: BacnetScanState.save_device_point_present_value_edit(index)
+                    ),
+                    rx.button(
+                        rx.icon("x", size=12),
+                        size="1",
+                        color_scheme="red",
+                        on_click=lambda: BacnetScanState.cancel_device_point_present_value_edit(index)
+                    )
+                ),
+                rx.fragment(
+                    rx.text(point.present_value),
+                    rx.button(
+                        rx.icon("pencil", size=12),
+                        size="1",
+                        on_click=lambda: BacnetScanState.enable_device_point_present_value_edit(index)
+                    )
+                )
+            ),
+            spacing="2"
+        )
+    )
+
 def show_device_point(point: BACnetDevicePointModelView, index: int) -> rx.Component:
     return rx.table.row(
         rx.table.cell(
@@ -151,7 +187,7 @@ def show_device_point(point: BACnetDevicePointModelView, index: int) -> rx.Compo
                 false_writable_badge()
             )
         ),
-        rx.table.cell(point.present_value),
+        present_value_cell(point, index),
         rx.table.cell(point.units),
         rx.table.cell(point.notes),
     )

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -35,6 +35,17 @@ def point_table_view_filter_dialog() -> rx.Component:
                                 ),
                             ),
                             form_entry.form_entry(
+                                "Object Type",
+                                rx.vstack(
+                                    rx.checkbox(
+                                        name="object_type", default_checked=BacnetScanState.point_table_filters.object_type
+                                    ),
+                                    justify="center",
+                                    align="center",
+                                    width="100%"
+                                ),
+                            ),
+                            form_entry.form_entry(
                                 "Present Value",
                                 rx.vstack(
                                     rx.checkbox(
@@ -115,11 +126,25 @@ def point_table_view_filter_dialog() -> rx.Component:
             )
         )
 
+def device_point_dialog_table_headers() -> rx.Component:
+    return rx.fragment(
+        rx.table.column_header_cell("Units"),
+        rx.table.column_header_cell("BACnet Object Type"),
+        rx.table.column_header_cell("Present Value"),
+        rx.table.column_header_cell("Writable"),
+        rx.table.column_header_cell("Index"),
+        rx.table.column_header_cell("Notes"),
+    )
+
 def device_point_table_headers() -> rx.Component:
     return rx.fragment(
         rx.cond(
             BacnetScanState.point_table_filters.units,
             rx.table.column_header_cell("Units")
+        ),
+        rx.cond(
+            BacnetScanState.point_table_filters.object_type,
+            rx.table.column_header_cell("BACnet Object Type")
         ),
         rx.cond(
             BacnetScanState.point_table_filters.present_value,
@@ -169,6 +194,9 @@ def show_selected_points_table() -> rx.Component:
     def show_row(point: BACnetDevicePointModelView) -> rx.Component:
         return rx.table.row(
             rx.table.cell(point.device_name),
+            rx.table.cell(point.units),
+            rx.table.cell(point.object_type),
+            rx.table.cell(point.present_value),
             rx.table.cell(
                 rx.cond(
                     point.writable,
@@ -176,8 +204,7 @@ def show_selected_points_table() -> rx.Component:
                     false_writable_badge()
                 )
             ),
-            rx.table.cell(point.present_value),
-            rx.table.cell(point.units),
+            rx.table.cell(point.index),
             rx.table.cell(point.notes)
         )
     
@@ -185,7 +212,7 @@ def show_selected_points_table() -> rx.Component:
         rx.table.header(
             rx.table.row(
                 rx.table.column_header_cell("VOLTTRON Point Name"),
-                device_point_table_headers(),
+                device_point_dialog_table_headers(),
             ),
         ),
         rx.table.body(
@@ -202,7 +229,7 @@ def export_points_dialog() -> rx.Component:
                 rx.button(
                     rx.hstack(
                         rx.icon("upload", size=15),
-                        rx.text("Export"),
+                        rx.text("Export to CSV"),
                         align="center",
                         justify="center",
                         spacing="2"
@@ -216,7 +243,7 @@ def export_points_dialog() -> rx.Component:
                 )
             ),
             rx.dialog.content(
-                rx.dialog.title("Export Contents"),
+                rx.dialog.title("CSV Contents"),
                 rx.dialog.description(f"{BacnetScanState.selected_points.length()} points selected for exporting."),
                 rx.inset(
                     show_selected_points_table(),
@@ -237,9 +264,10 @@ def export_points_dialog() -> rx.Component:
                         ),
                         rx.dialog.close(
                             rx.button(
-                                "Export",
+                                "Export to CSV",
                                 variant="soft",
-                                size="2"
+                                size="2",
+                                on_click=lambda: BacnetScanState.export_to_csv
                             ),
                         ),
                         width="100%",
@@ -249,7 +277,9 @@ def export_points_dialog() -> rx.Component:
                     spacing="6",
                     width="100%"
                 ),
-                on_close_auto_focus=lambda: BacnetScanState.on_selected_points_dialog_close
+                on_close_auto_focus=lambda: BacnetScanState.on_selected_points_dialog_close,
+                max_width="100rem",
+                width="clamp(20rem, 80vw, 100rem)",
             )
         )
 
@@ -305,7 +335,9 @@ def add_to_registry_config_file_dialog() -> rx.Component:
                     spacing="6",
                     width="100%"
                 ),
-                on_close_auto_focus=lambda: BacnetScanState.on_selected_points_dialog_close
+                on_close_auto_focus=lambda: BacnetScanState.on_selected_points_dialog_close,
+                max_width="100rem",
+                width="clamp(20rem, 80vw, 100rem)",
             )
         )
 
@@ -477,6 +509,10 @@ def show_device_point(point: BACnetDevicePointModelView, index: int) -> rx.Compo
         rx.cond(
             BacnetScanState.point_table_filters.units,
             rx.table.cell(point.units)
+        ),
+        rx.cond(
+            BacnetScanState.point_table_filters.units,
+            rx.table.cell(point.object_type)
         ),
         rx.cond(
             BacnetScanState.point_table_filters.present_value,

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -4,6 +4,104 @@ from ..components.form_components import form_entry
 from ..layouts import app_layout_sidebar
 from ..model_views import BACnetDeviceModelView, BACnetDevicePointModelView
 
+def point_table_view_filter_dialog() -> rx.Component:
+    return rx.dialog.root(
+            rx.dialog.trigger(
+                rx.button(
+                        rx.hstack(
+                            rx.icon("sliders-horizontal", size=15),
+                            rx.text("Filter Table View"),
+                            align="center",
+                            spacing="2"
+                        ), 
+                        size="1",
+                    )
+            ),
+            rx.dialog.content(
+                rx.dialog.title("Filter Points Table View"),
+                rx.dialog.description(f"Select columns to display or hide."),
+                rx.form(
+                    rx.vstack(
+                        rx.vstack(
+                            form_entry.form_entry(
+                                "Writable",
+                                rx.vstack(
+                                    rx.checkbox(
+                                        name="writable"
+                                    ),
+                                    justify="center",
+                                    align="center",
+                                    width="100%"
+                                ),
+                            ),
+                            form_entry.form_entry(
+                                "Present Value",
+                                rx.vstack(
+                                    rx.checkbox(
+                                        name="present_value"
+                                    ),
+                                    justify="center",
+                                    align="center",
+                                    width="100%"
+                                ),
+                            ),
+                            form_entry.form_entry(
+                                "Units",
+                                rx.vstack(
+                                    rx.checkbox(
+                                        name="units"
+                                    ),
+                                    justify="center",
+                                    align="center",
+                                    width="100%"
+                                ),
+                            ),
+                            form_entry.form_entry(
+                                "Notes",
+                                rx.vstack(
+                                    rx.checkbox(
+                                        name="notes"
+                                    ),
+                                    justify="center",
+                                    align="center",
+                                    width="100%"
+                                ),
+                            ),
+                            margin_top="24px",
+                            spacing="3",
+                            height="100%",
+                            justify="center",
+                            align="center",
+                            width="100%"
+                        ),
+                        rx.hstack(
+                            rx.dialog.close(
+                                rx.button(
+                                    "Close",
+                                    color_scheme="gray",
+                                    variant="soft",
+                                    size="2"
+                                ),
+                            ),
+                            rx.dialog.close(
+                                rx.button(
+                                    "Save",
+                                    variant="soft",
+                                    size="2"
+                                ),
+                            ),
+                            width="100%",
+                            justify="between",
+                            spacing="2"
+                        ),
+                        spacing="6",
+                        width="100%"
+                    )
+                ),
+                on_close_auto_focus=lambda: BacnetScanState.on_selected_points_dialog_close
+            )
+        )
+
 def device_point_table_headers() -> rx.Component:
     return rx.fragment(
         rx.table.column_header_cell("Writable"),
@@ -131,7 +229,7 @@ def add_to_registry_config_file_dialog() -> rx.Component:
             rx.dialog.trigger(
                 rx.button(
                     rx.hstack(
-                        rx.icon("settings", size=15),
+                        rx.icon("plus", size=15),
                         rx.text("Create a Registry Config File"),
                         align="center",
                         spacing="2"
@@ -146,7 +244,7 @@ def add_to_registry_config_file_dialog() -> rx.Component:
             ),
             rx.dialog.content(
                 rx.dialog.title("Registry Config File Contents"),
-                rx.dialog.description(f"{BacnetScanState.selected_points.length()} points are to be added to a registry config file."),
+                rx.dialog.description(f"{BacnetScanState.selected_points.length()} points selected to create a registry config file."),
                 rx.inset(
                     show_selected_points_table(),
                     side="x",
@@ -386,14 +484,18 @@ def show_device(device: BACnetDeviceModelView, index: int) -> rx.Component:
                             margin_bottom="12px"
                         ),
                         rx.hstack(
-                            rx.input(
-                                rx.input.slot(
-                                    rx.icon("search", size=15)
+                            rx.hstack(
+                                rx.input(
+                                    rx.input.slot(
+                                        rx.icon("search", size=15)
+                                    ),
+                                    placeholder="Search",
+                                    variant="surface",
+                                    size="1"
                                 ),
-                                placeholder="Search",
-                                variant="surface",
-                                size="1"
+                                spacing="2"
                             ),
+                            point_table_view_filter_dialog(),
                             rx.hstack(
                                 export_points_dialog(),
                                 add_to_registry_config_file_dialog(),

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -382,10 +382,18 @@ def show_device(device: BACnetDeviceModelView, index: int) -> rx.Component:
                             rx.text("Device Points", size="1", weight="bold"),
                             rx.text(f"Select points to export or configure to a platform", size="1", color="gray"),
                             rx.text(f"{BacnetScanState.selected_points.length()} points selected", size="1", color="gray"),
-                            spacing="1"
+                            spacing="1",
+                            margin_bottom="12px"
                         ),
                         rx.hstack(
-                            rx.box(),
+                            rx.input(
+                                rx.input.slot(
+                                    rx.icon("search", size=15)
+                                ),
+                                placeholder="Search",
+                                variant="surface",
+                                size="1"
+                            ),
                             rx.hstack(
                                 export_points_dialog(),
                                 add_to_registry_config_file_dialog(),

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -24,10 +24,10 @@ def point_table_view_filter_dialog() -> rx.Component:
                     rx.vstack(
                         rx.vstack(
                             form_entry.form_entry(
-                                "Writable",
+                                "Units",
                                 rx.vstack(
                                     rx.checkbox(
-                                        name="writable"
+                                        name="units", default_checked=BacnetScanState.point_table_filters.units
                                     ),
                                     justify="center",
                                     align="center",
@@ -38,7 +38,7 @@ def point_table_view_filter_dialog() -> rx.Component:
                                 "Present Value",
                                 rx.vstack(
                                     rx.checkbox(
-                                        name="present_value"
+                                        name="present_value", default_checked=BacnetScanState.point_table_filters.present_value
                                     ),
                                     justify="center",
                                     align="center",
@@ -46,10 +46,21 @@ def point_table_view_filter_dialog() -> rx.Component:
                                 ),
                             ),
                             form_entry.form_entry(
-                                "Units",
+                                "Writable",
                                 rx.vstack(
                                     rx.checkbox(
-                                        name="units"
+                                        name="writable", default_checked=BacnetScanState.point_table_filters.writable
+                                    ),
+                                    justify="center",
+                                    align="center",
+                                    width="100%"
+                                ),
+                            ),
+                            form_entry.form_entry(
+                                "Index",
+                                rx.vstack(
+                                    rx.checkbox(
+                                        name="index", default_checked=BacnetScanState.point_table_filters.index
                                     ),
                                     justify="center",
                                     align="center",
@@ -60,7 +71,7 @@ def point_table_view_filter_dialog() -> rx.Component:
                                 "Notes",
                                 rx.vstack(
                                     rx.checkbox(
-                                        name="notes"
+                                        name="notes", default_checked=BacnetScanState.point_table_filters.notes
                                     ),
                                     justify="center",
                                     align="center",
@@ -87,7 +98,8 @@ def point_table_view_filter_dialog() -> rx.Component:
                                 rx.button(
                                     "Save",
                                     variant="soft",
-                                    size="2"
+                                    size="2",
+                                    type="submit"
                                 ),
                             ),
                             width="100%",
@@ -96,7 +108,8 @@ def point_table_view_filter_dialog() -> rx.Component:
                         ),
                         spacing="6",
                         width="100%"
-                    )
+                    ),
+                    on_submit=BacnetScanState.save_point_table_filters
                 ),
                 on_close_auto_focus=lambda: BacnetScanState.on_selected_points_dialog_close
             )
@@ -104,10 +117,26 @@ def point_table_view_filter_dialog() -> rx.Component:
 
 def device_point_table_headers() -> rx.Component:
     return rx.fragment(
-        rx.table.column_header_cell("Writable"),
-        rx.table.column_header_cell("Present Value"),
-        rx.table.column_header_cell("Units"),
-        rx.table.column_header_cell("Notes"),
+        rx.cond(
+            BacnetScanState.point_table_filters.units,
+            rx.table.column_header_cell("Units")
+        ),
+        rx.cond(
+            BacnetScanState.point_table_filters.present_value,
+            rx.table.column_header_cell("Present Value")
+        ),
+        rx.cond(
+            BacnetScanState.point_table_filters.writable,
+            rx.table.column_header_cell("Writable")
+        ),
+        rx.cond(
+            BacnetScanState.point_table_filters.index,
+            rx.table.column_header_cell("Index")
+        ),
+        rx.cond(
+            BacnetScanState.point_table_filters.notes,
+            rx.table.column_header_cell("Notes"),
+        )
     )
 
 def selected_points_pagination() -> rx.Component:
@@ -444,17 +473,33 @@ def show_device_point(point: BACnetDevicePointModelView, index: int) -> rx.Compo
                 rx.text(point.device_name),
                 spacing="4"
             )
+        ),        
+        rx.cond(
+            BacnetScanState.point_table_filters.units,
+            rx.table.cell(point.units)
         ),
-        rx.table.cell(
-            rx.cond(
-                point.writable,
-                true_writable_badge(),
-                false_writable_badge()
+        rx.cond(
+            BacnetScanState.point_table_filters.present_value,
+            present_value_cell(point, index)
+        ),
+        rx.cond(
+            BacnetScanState.point_table_filters.writable,
+            rx.table.cell(
+                rx.cond(
+                    point.writable,
+                    true_writable_badge(),
+                    false_writable_badge()
+                )
             )
         ),
-        present_value_cell(point, index),
-        rx.table.cell(point.units),
-        rx.table.cell(point.notes),
+        rx.cond(
+            BacnetScanState.point_table_filters.index,
+            rx.table.cell(point.index)
+        ),
+        rx.cond(
+            BacnetScanState.point_table_filters.notes,
+            rx.table.cell(point.notes)
+        ),
     )
 
 def show_device(device: BACnetDeviceModelView, index: int) -> rx.Component:

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -131,6 +131,32 @@ def present_value_cell(point: BACnetDevicePointModelView, index: int) -> rx.Comp
         )
     )
 
+def device_point_table_pagination() -> rx.Component:
+    return rx.hstack(
+        rx.button(
+            rx.icon(
+                "chevron-left",
+                size=20
+            ),
+            disabled=~BacnetScanState.prev_page_allowed,
+            on_click=lambda: BacnetScanState.prev_point_page(),
+            size="1"
+        ),
+        rx.text(f"Page {BacnetScanState.points_table_page_number}/{BacnetScanState.total_pages}"),
+        rx.button(
+            rx.icon(
+                "chevron-right",
+                size=20
+            ),
+            disabled=~BacnetScanState.next_page_allowed,
+            on_click=lambda: BacnetScanState.next_point_page(),
+            size="1"
+        ),
+        width="100%",
+        justify="center",
+        align="center"
+        ),
+
 def show_device_point(point: BACnetDevicePointModelView, index: int) -> rx.Component:
     return rx.table.row(
         rx.table.cell(
@@ -216,7 +242,7 @@ def show_device(device: BACnetDeviceModelView, index: int) -> rx.Component:
                             ),
                             rx.table.body(
                                 rx.foreach(
-                                    BacnetScanState.selected_device.points,
+                                    BacnetScanState.points_to_load,
                                     show_device_point
                                 ),
                             ),
@@ -225,6 +251,7 @@ def show_device(device: BACnetDeviceModelView, index: int) -> rx.Component:
                             border_color="#272727FF",
                             border_radius=".5rem",
                         ),
+                        device_point_table_pagination(),
                         spacing="2",
                         padding="1em",
                         border_radius="6px",

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -1412,7 +1412,7 @@ def network_information_card() -> rx.Component:
                                 # Windows Host IP info
                                 rx.fragment(
                                     rx.text("Host IP"),
-                                    rx.text(BacnetScanState.windows_host_ip_info.windows_host_ip),
+                                    rx.text(BacnetScanState.windows_host_ip_info.address),
                                 )
                             ),
                             columns="2",

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -943,13 +943,15 @@ def show_device_point(point_tuple: tuple[int, BACnetDevicePointModelView], index
         rx.cond(
             BacnetScanState.point_column_filter.writable,
             rx.table.cell(
-                rx.box(
+                rx.button(
                     rx.cond(
                     point.writable,
                         true_writable_badge(),
                         false_writable_badge()
                     ),
                     disabled=point.never_writable,
+                    variant="ghost",
+                    padding="0px",
                     cursor=rx.cond(
                         point.never_writable,
                         "not-allowed",

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -722,7 +722,7 @@ def add_to_registry_config_file_dialog() -> rx.Component:
                             True,
                             False
                         ),
-                        on_click=BacnetScanState.close_dialogs,  # Or your confirm logic
+                        on_click=BacnetScanState.on_add_to_registry_config,  # Or your confirm logic
                     ),
                     width="100%",
                     justify="end",

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -38,7 +38,8 @@ def volttron_point_name_filter_popover() -> rx.Component:
                         "VOLTTRON Point Name Filter",
                         rx.input(
                             width="100%",
-                            name="units",
+                            placeholder="Filter for a value",
+                            name="volttron_point_name",
                             default_value=BacnetScanState.point_table_filter.volttron_point_name,
                         )
                     ),
@@ -67,6 +68,7 @@ def units_filter_popover() -> rx.Component:
                         "Units Filter",
                         rx.input(
                             width="100%",
+                            placeholder="Filter for a value",
                             name="units",
                             default_value=BacnetScanState.point_table_filter.units,
                         )
@@ -95,6 +97,7 @@ def object_type_filter_popover() -> rx.Component:
                     form_entry.form_entry(
                         "BACnet Object Type Filter",
                         rx.input(
+                            placeholder="Filter for a value",
                             name="object_type",
                             default_value=BacnetScanState.point_table_filter.object_type,
                             width="100%"
@@ -124,6 +127,7 @@ def present_value_filter_popover() -> rx.Component:
                     form_entry.form_entry(
                         "Present Value Filter",
                         rx.input(
+                            placeholder="Filter for a value",
                             name="present_value",
                             default_value=BacnetScanState.point_table_filter.present_value,
                             width="100%"
@@ -184,6 +188,7 @@ def index_filter_popover() -> rx.Component:
                         "Index Filter",
                         rx.input(
                             name="index",
+                            placeholder="Filter for a value",
                             default_value=BacnetScanState.point_table_filter.index,
                             width="100%"
                         )
@@ -213,6 +218,7 @@ def notes_filter_popover() -> rx.Component:
                         "Notes Filter",
                         rx.input(
                             name="notes",
+                            placeholder="Filter for a value",
                             default_value=BacnetScanState.point_table_filter.notes,
                             width="100%"
                         )
@@ -913,7 +919,8 @@ def device_point_table_pagination() -> rx.Component:
         align="center"
     )
 
-def show_device_point(point: BACnetDevicePointModelView, index: int) -> rx.Component:
+def show_device_point(point_tuple: tuple[int, BACnetDevicePointModelView], index: int) -> rx.Component:
+    point = point_tuple[1]
     return rx.table.row(
         volttron_point_name_cell(point, index),
         rx.cond(
@@ -975,17 +982,6 @@ def show_device(device: BACnetDeviceModelView, index: int) -> rx.Component:
                             margin_bottom="12px"
                         ),
                         rx.hstack(
-                            rx.hstack(
-                                rx.input(
-                                    rx.input.slot(
-                                        rx.icon("search", size=15)
-                                    ),
-                                    placeholder="Search",
-                                    variant="surface",
-                                    size="1"
-                                ),
-                                spacing="2"
-                            ),
                             point_column_filter_dialog(),
                             rx.hstack(
                                 export_points_dialog(),
@@ -1008,7 +1004,17 @@ def show_device(device: BACnetDeviceModelView, index: int) -> rx.Component:
                                                 rx.text("VOLTTRON Point Name", weight="bold"),
                                                 spacing="4"
                                             ),
-                                            volttron_point_name_filter_popover(),
+                                            rx.hstack(
+                                                volttron_point_name_filter_popover(),
+                                                rx.cond(
+                                                    BacnetScanState.point_table_filter.volttron_point_name != "",
+                                                    filter_badge(
+                                                        BacnetScanState.point_table_filter.volttron_point_name,
+                                                        on_click=lambda: BacnetScanState.clear_point_filter("volttron_point_name"),
+                                                    )
+                                                ),
+                                                wrap="wrap"
+                                            ),
                                             align="center",
                                             spacing="2"
                                         )

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -1,6 +1,7 @@
 import reflex as rx
-from ..state import BacnetScanState, ToolState
+from ..state import BacnetScanState, ToolState, PlatformPageState
 from ..components.form_components import form_entry
+from ..components.tiles import platform_tile
 from ..layouts import app_layout_sidebar
 from ..model_views import BACnetDeviceModelView, BACnetDevicePointModelView
 
@@ -10,7 +11,7 @@ def point_table_view_filter_dialog() -> rx.Component:
                 rx.button(
                         rx.hstack(
                             rx.icon("sliders-horizontal", size=15),
-                            rx.text("Filter Table View"),
+                            rx.text("Toggle Columns"),
                             align="center",
                             spacing="2"
                         ), 
@@ -35,7 +36,7 @@ def point_table_view_filter_dialog() -> rx.Component:
                                 ),
                             ),
                             form_entry.form_entry(
-                                "Object Type",
+                                "BACnet Object Type",
                                 rx.vstack(
                                     rx.checkbox(
                                         name="object_type", default_checked=BacnetScanState.point_table_filters.object_type
@@ -128,6 +129,8 @@ def point_table_view_filter_dialog() -> rx.Component:
 
 def device_point_dialog_table_headers() -> rx.Component:
     return rx.fragment(
+        rx.table.column_header_cell("Point Name"),
+        rx.table.column_header_cell("VOLTTRON Point Name"),
         rx.table.column_header_cell("Units"),
         rx.table.column_header_cell("BACnet Object Type"),
         rx.table.column_header_cell("Present Value"),
@@ -194,6 +197,7 @@ def show_selected_points_table() -> rx.Component:
     def show_row(point: BACnetDevicePointModelView) -> rx.Component:
         return rx.table.row(
             rx.table.cell(point.device_name),
+            rx.table.cell(point.volttron_point_name),
             rx.table.cell(point.units),
             rx.table.cell(point.object_type),
             rx.table.cell(point.present_value),
@@ -211,7 +215,6 @@ def show_selected_points_table() -> rx.Component:
     return rx.table.root(
         rx.table.header(
             rx.table.row(
-                rx.table.column_header_cell("VOLTTRON Point Name"),
                 device_point_dialog_table_headers(),
             ),
         ),
@@ -284,7 +287,8 @@ def export_points_dialog() -> rx.Component:
         )
 
 def add_to_registry_config_file_dialog() -> rx.Component:
-    return rx.dialog.root(
+    return rx.fragment(
+        rx.dialog.root(
             rx.dialog.trigger(
                 rx.button(
                     rx.hstack(
@@ -292,18 +296,21 @@ def add_to_registry_config_file_dialog() -> rx.Component:
                         rx.text("Create a Registry Config File"),
                         align="center",
                         spacing="2"
-                    ), 
+                    ),
                     size="1",
                     disabled=rx.cond(
                         BacnetScanState.selected_points.length() == 0,
                         True,
                         False
-                    )
+                    ),
+                    on_click=BacnetScanState.open_registry_dialog,
                 )
             ),
             rx.dialog.content(
                 rx.dialog.title("Registry Config File Contents"),
-                rx.dialog.description(f"{BacnetScanState.selected_points.length()} points selected to create a registry config file."),
+                rx.dialog.description(
+                    f"{BacnetScanState.selected_points.length()} points selected to create a registry config file."
+                ),
                 rx.inset(
                     show_selected_points_table(),
                     side="x",
@@ -313,20 +320,18 @@ def add_to_registry_config_file_dialog() -> rx.Component:
                 rx.vstack(
                     selected_points_pagination(),
                     rx.hstack(
-                        rx.dialog.close(
-                            rx.button(
-                                "Close",
-                                color_scheme="gray",
-                                variant="soft",
-                                size="2"
-                            ),
+                        rx.button(
+                            "Close",
+                            color_scheme="gray",
+                            variant="soft",
+                            size="2",
+                            on_click=BacnetScanState.close_dialogs,
                         ),
-                        rx.dialog.close(
-                            rx.button(
-                                "Add to Registry Config File",
-                                variant="soft",
-                                size="2"
-                            ),
+                        rx.button(
+                            "Add to Registry Config File",
+                            variant="soft",
+                            size="2",
+                            on_click=BacnetScanState.open_select_platform_dialog,
                         ),
                         width="100%",
                         justify="end",
@@ -335,11 +340,54 @@ def add_to_registry_config_file_dialog() -> rx.Component:
                     spacing="6",
                     width="100%"
                 ),
-                on_close_auto_focus=lambda: BacnetScanState.on_selected_points_dialog_close,
                 max_width="100rem",
                 width="clamp(20rem, 80vw, 100rem)",
-            )
-        )
+            ),
+            open=BacnetScanState.dialog_registry_open,
+        ),
+
+        # Selecting Platforms Dialog
+        rx.dialog.root(
+            rx.dialog.content(
+                rx.dialog.title("Select Platforms"),
+                rx.dialog.description("Are you sure you want to add to the registry config file?"),
+                rx.hstack(
+                    rx.foreach(
+                        PlatformPageState.in_file_platforms,
+                        lambda platform: platform_tile.platform_tile(
+                            platform.platform.config.instance_name,
+                            platform
+                        )
+                    ),
+                    wrap="wrap",
+                    spacing="6",
+                    padding="1rem",
+                    margin_top="24px",
+                    margin_bottom="24px",
+                ),
+                rx.hstack(
+                    rx.button(
+                        "Cancel",
+                        color_scheme="gray",
+                        variant="soft",
+                        size="2",
+                        on_click=BacnetScanState.close_dialogs,
+                    ),
+                    rx.button(
+                        "Confirm",
+                        color_scheme="green",
+                        variant="soft",
+                        size="2",
+                        on_click=BacnetScanState.close_dialogs,  # Or your confirm logic
+                    ),
+                    width="100%",
+                    justify="end",
+                    spacing="2"
+                ),
+            ),
+            open=BacnetScanState.dialog_select_platform_open,
+        ),
+    )
 
 def scan_for_devices_card():
     return rx.box(
@@ -468,6 +516,50 @@ def present_value_cell(point: BACnetDevicePointModelView, index: int) -> rx.Comp
         )
     )
 
+
+def volttron_point_name_cell(point: BACnetDevicePointModelView, index: int) -> rx.Component:
+    return rx.table.cell(
+        rx.hstack(
+            rx.checkbox(
+                on_change=lambda checked: BacnetScanState.handle_device_check(index, checked), 
+                checked=point.selected
+            ),
+            rx.hstack(
+                rx.cond(
+                    point.volttron_point_name_editing,
+                    rx.fragment(
+                        rx.text_field(
+                            value=point.volttron_point_name,
+                            size="1",
+                            on_change=lambda v: BacnetScanState.handle_volttron_point_name_value_edit(index, v)
+                        ),
+                        rx.button(
+                            rx.icon("save", size=12),
+                            size="1",
+                            on_click=lambda: BacnetScanState.save_device_point_volttron_point_name_value_edit(index)
+                        ),
+                        rx.button(
+                            rx.icon("x", size=12),
+                            size="1",
+                            color_scheme="red",
+                            on_click=lambda: BacnetScanState.cancel_device_point_volttron_point_name_value_edit(index)
+                        )
+                    ),
+                    rx.fragment(
+                        rx.text(point.volttron_point_name),
+                        rx.button(
+                            rx.icon("pencil", size=12),
+                            size="1",
+                            on_click=lambda: BacnetScanState.enable_device_point_volttron_point_name_value_edit(index)
+                        )
+                    )
+                ),
+                spacing="2"
+            ),
+            spacing="4"
+        )
+    )
+
 def device_point_table_pagination() -> rx.Component:
     return rx.hstack(
         rx.button(
@@ -496,22 +588,13 @@ def device_point_table_pagination() -> rx.Component:
 
 def show_device_point(point: BACnetDevicePointModelView, index: int) -> rx.Component:
     return rx.table.row(
-        rx.table.cell(
-            rx.hstack(
-                rx.checkbox(
-                    on_change=lambda checked: BacnetScanState.handle_device_check(index, checked), 
-                    checked=point.selected
-                ), 
-                rx.text(point.device_name),
-                spacing="4"
-            )
-        ),        
+        volttron_point_name_cell(point, index),
         rx.cond(
             BacnetScanState.point_table_filters.units,
             rx.table.cell(point.units)
         ),
         rx.cond(
-            BacnetScanState.point_table_filters.units,
+            BacnetScanState.point_table_filters.object_type,
             rx.table.cell(point.object_type)
         ),
         rx.cond(

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -4,6 +4,184 @@ from ..components.form_components import form_entry
 from ..layouts import app_layout_sidebar
 from ..model_views import BACnetDeviceModelView, BACnetDevicePointModelView
 
+def device_point_table_headers() -> rx.Component:
+    return rx.fragment(
+        rx.table.column_header_cell("Writable"),
+        rx.table.column_header_cell("Present Value"),
+        rx.table.column_header_cell("Units"),
+        rx.table.column_header_cell("Notes"),
+    )
+
+def selected_points_pagination() -> rx.Component:
+    return rx.hstack(
+        rx.button(
+            rx.icon(
+                "chevron-left",
+                size=20
+            ),
+            disabled=~BacnetScanState.selected_points_has_prev_page,
+            on_click=lambda: BacnetScanState.selected_points_prev_page(),
+            size="1"
+        ),
+        rx.text(f"Page {BacnetScanState.selected_points_page_number}/{BacnetScanState.selected_points_total_pages}"),
+        rx.button(
+            rx.icon(
+                "chevron-right",
+                size=20
+            ),
+            disabled=~BacnetScanState.selected_points_has_next_page,
+            on_click=lambda: BacnetScanState.selected_points_next_page(),
+            size="1"
+        ),
+        width="100%",
+        justify="center",
+        align="center"
+    )
+
+def show_selected_points_table() -> rx.Component:
+    def show_row(point: BACnetDevicePointModelView) -> rx.Component:
+        return rx.table.row(
+            rx.table.cell(point.device_name),
+            rx.table.cell(
+                rx.cond(
+                    point.writable,
+                    true_writable_badge(),
+                    false_writable_badge()
+                )
+            ),
+            rx.table.cell(point.present_value),
+            rx.table.cell(point.units),
+            rx.table.cell(point.notes)
+        )
+    
+    return rx.table.root(
+        rx.table.header(
+            rx.table.row(
+                rx.table.column_header_cell("VOLTTRON Point Name"),
+                device_point_table_headers(),
+            ),
+        ),
+        rx.table.body(
+            rx.foreach(
+                BacnetScanState.paginated_selected_points,
+                show_row
+            )
+        )
+    )
+
+def export_points_dialog() -> rx.Component:
+    return rx.dialog.root(
+            rx.dialog.trigger(
+                rx.button(
+                    rx.hstack(
+                        rx.icon("upload", size=15),
+                        rx.text("Export"),
+                        align="center",
+                        justify="center",
+                        spacing="2"
+                    ), 
+                    size="1",
+                    disabled=rx.cond(
+                        BacnetScanState.selected_points.length() == 0,
+                        True,
+                        False
+                    )
+                )
+            ),
+            rx.dialog.content(
+                rx.dialog.title("Export Contents"),
+                rx.dialog.description(f"{BacnetScanState.selected_points.length()} points selected for exporting."),
+                rx.inset(
+                    show_selected_points_table(),
+                    side="x",
+                    margin_top="24px",
+                    margin_bottom="24px",
+                ),
+                rx.vstack(
+                    selected_points_pagination(),
+                    rx.hstack(
+                        rx.dialog.close(
+                            rx.button(
+                                "Close",
+                                color_scheme="gray",
+                                variant="soft",
+                                size="2"
+                            ),
+                        ),
+                        rx.dialog.close(
+                            rx.button(
+                                "Export",
+                                variant="soft",
+                                size="2"
+                            ),
+                        ),
+                        width="100%",
+                        justify="end",
+                        spacing="2"
+                    ),
+                    spacing="6",
+                    width="100%"
+                ),
+                on_close_auto_focus=lambda: BacnetScanState.on_selected_points_dialog_close
+            )
+        )
+
+def add_to_registry_config_file_dialog() -> rx.Component:
+    return rx.dialog.root(
+            rx.dialog.trigger(
+                rx.button(
+                    rx.hstack(
+                        rx.icon("settings", size=15),
+                        rx.text("Create a Registry Config File"),
+                        align="center",
+                        spacing="2"
+                    ), 
+                    size="1",
+                    disabled=rx.cond(
+                        BacnetScanState.selected_points.length() == 0,
+                        True,
+                        False
+                    )
+                )
+            ),
+            rx.dialog.content(
+                rx.dialog.title("Registry Config File Contents"),
+                rx.dialog.description(f"{BacnetScanState.selected_points.length()} points are to be added to a registry config file."),
+                rx.inset(
+                    show_selected_points_table(),
+                    side="x",
+                    margin_top="24px",
+                    margin_bottom="24px",
+                ),
+                rx.vstack(
+                    selected_points_pagination(),
+                    rx.hstack(
+                        rx.dialog.close(
+                            rx.button(
+                                "Close",
+                                color_scheme="gray",
+                                variant="soft",
+                                size="2"
+                            ),
+                        ),
+                        rx.dialog.close(
+                            rx.button(
+                                "Add to Registry Config File",
+                                variant="soft",
+                                size="2"
+                            ),
+                        ),
+                        width="100%",
+                        justify="end",
+                        spacing="2"
+                    ),
+                    spacing="6",
+                    width="100%"
+                ),
+                on_close_auto_focus=lambda: BacnetScanState.on_selected_points_dialog_close
+            )
+        )
+
 def scan_for_devices_card():
     return rx.box(
         rx.box(  # CardHeader
@@ -155,7 +333,7 @@ def device_point_table_pagination() -> rx.Component:
         width="100%",
         justify="center",
         align="center"
-        ),
+    )
 
 def show_device_point(point: BACnetDevicePointModelView, index: int) -> rx.Component:
     return rx.table.row(
@@ -200,27 +378,22 @@ def show_device(device: BACnetDeviceModelView, index: int) -> rx.Component:
             rx.table.row(
                 rx.table.cell(
                     rx.vstack(
-                        # rx.hstack(
-                            rx.vstack(
-                                rx.text("Device Points", size="1", weight="bold"),
-                                rx.text(f"Select points to export or configure to a platform", size="1", color="gray"),
-                                spacing="1"
+                        rx.vstack(
+                            rx.text("Device Points", size="1", weight="bold"),
+                            rx.text(f"Select points to export or configure to a platform", size="1", color="gray"),
+                            rx.text(f"{BacnetScanState.selected_points.length()} points selected", size="1", color="gray"),
+                            spacing="1"
+                        ),
+                        rx.hstack(
+                            rx.box(),
+                            rx.hstack(
+                                export_points_dialog(),
+                                add_to_registry_config_file_dialog(),
+                                spacing="2"
                             ),
-                            # TODO make this a dialog trigger
-                            # rx.button(
-                            #     "Create a Registry Config File", 
-                            #     size="1",
-                            #     disabled=rx.cond(
-                            #         BacnetScanState.selected_points.length() > 0,
-                            #         False,
-                            #         True
-                            #     )
-                            # ),
-                            # justify="between",
-                            # width="100%"
-                        # ), make it bigger, 
-                        # Add your expanded content here, e.g. a nested table of points
-                        # rx.table(...),
+                            width="100%",
+                            justify="between"
+                        ),
                         rx.table.root(
                             rx.table.header(
                                 rx.table.row(
@@ -234,10 +407,7 @@ def show_device(device: BACnetDeviceModelView, index: int) -> rx.Component:
                                             spacing="4"
                                         )
                                     ),
-                                    rx.table.column_header_cell("Writable"),
-                                    rx.table.column_header_cell("Present Value"),
-                                    rx.table.column_header_cell("Units"),
-                                    rx.table.column_header_cell("Notes"),
+                                    device_point_table_headers(),
                                 )
                             ),
                             rx.table.body(
@@ -319,11 +489,11 @@ def discovered_devices_card() -> rx.Component:
                         )
                     )
                 ),
-                height="1000px",
+                height="1300px",
                 overflow_y="auto",
             ),
         ),
-        min_height="1000px",
+        min_height="1400px",
         border="1px solid",
         border_color="grey",
         border_radius=".5rem",

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -684,50 +684,105 @@ def add_to_registry_config_file_dialog() -> rx.Component:
             rx.dialog.content(
                 rx.dialog.title("Select a Platform"),
                 rx.dialog.description("Select a platform to add the registry config file to."),
-                rx.hstack(
-                    rx.foreach(
-                        PlatformPageState.in_file_platforms,
-                        lambda platform: platform_tile.platform_tile(
-                            platform.platform.config.instance_name,
-                            platform,
-                            background_color=rx.cond(
-                                BacnetScanState.selected_platform_uid == platform.platform.config.instance_name,
-                                "#44C0ED",
-                                "rgba(145, 145, 145, 0.29)"
+                rx.form(
+                    # Replace the simple grid with a grid that has custom column widths
+                    rx.grid(
+                        # First column (70%) - Platform listings
+                        rx.box(
+                            rx.vstack(
+                                rx.hstack(
+                                    rx.foreach(
+                                        PlatformPageState.in_file_platforms,
+                                        lambda platform: platform_tile.platform_tile(
+                                            platform.platform.config.instance_name,
+                                            platform,
+                                            background_color=rx.cond(
+                                                BacnetScanState.selected_platform_uid == platform.platform.config.instance_name,
+                                                "#44C0ED",
+                                                "rgba(145, 145, 145, 0.29)"
+                                            ),
+                                            on_click=lambda: BacnetScanState.select_platform_for_registry_config(platform.platform.config.instance_name)
+                                        )
+                                    ),
+                                    wrap="wrap",
+                                    spacing="6",
+                                    padding="1rem",
+                                    margin_top="24px",
+                                ),
+                                rx.cond(
+                                    BacnetScanState.platform_has_platform_driver == False,
+                                    rx.text(
+                                        "This selected platform doesn't already contain a platform.driver agent, confirming will automatically add a platform.driver agent to the platform along side the registry config within it's config store.",
+                                        size="1",
+                                        color="#ffa057",
+                                        padding="8px 12px",
+                                        border_radius="6px",
+                                        background_color="#66350c63",
+                                        margin_button="24px",
+                                    )
+                                ),
+                                width="100%",  # Take full width of this grid cell
+                                spacing="3"
                             ),
-                            on_click=lambda: BacnetScanState.select_platform_for_registry_config(platform.platform.config.instance_name)
-                        )
-                    ),
-                    wrap="wrap",
-                    spacing="6",
-                    padding="1rem",
-                    margin_top="24px",
-                    margin_bottom="24px",
-                ),
-                rx.hstack(
-                    rx.button(
-                        "Cancel",
-                        color_scheme="gray",
-                        variant="soft",
-                        size="2",
-                        on_click=BacnetScanState.close_dialogs,
-                    ),
-                    rx.button(
-                        "Confirm",
-                        color_scheme="green",
-                        variant="soft",
-                        size="2",
-                        disabled=rx.cond(
-                            BacnetScanState.selected_platform_uid == "",
-                            True,
-                            False
+                            width="100%",  # Take full width of this grid cell,
                         ),
-                        on_click=BacnetScanState.on_add_to_registry_config,  # Or your confirm logic
+                        
+                        # Second column (30%) - Form entry
+                        rx.box(
+                            form_entry.form_entry(
+                                "Path",
+                                rx.input(
+                                    placeholder="Provide a path to save the registry config file",
+                                    # width="100%",  # Modified to take full width of its container
+                                    default_value="points.csv",
+                                    name="path",
+                                    disabled=rx.cond(
+                                        BacnetScanState.selected_platform_uid == "",
+                                        True,
+                                        False
+                                    ),
+                                    required=True,
+                                ),
+                                required_entry=True,
+                            ),
+                            width="100%",  # Take full width of this grid cell
+                            margin_top="24px",
+                        ),
+                        
+                        # Define custom grid template columns for the 70/30 split
+                        template_columns={"base": "1fr", "md": "70% 30%"},
+                        gap="4",
+                        width="100%",
                     ),
-                    width="100%",
-                    justify="end",
-                    spacing="2"
+                    
+                    rx.hstack(
+                        rx.button(
+                            "Cancel",
+                            color_scheme="gray",
+                            variant="soft",
+                            size="2",
+                            on_click=BacnetScanState.close_dialogs,
+                        ),
+                        rx.button(
+                            "Confirm",
+                            color_scheme="green",
+                            variant="soft",
+                            size="2",
+                            type="submit",
+                            disabled=rx.cond(
+                                BacnetScanState.selected_platform_uid == "",
+                                True,
+                                False
+                            ),
+                        ),
+                        width="100%",
+                        justify="end",
+                        spacing="2"
+                    ),
+                    on_submit=BacnetScanState.on_add_to_registry_config_confirm
                 ),
+                max_width="100rem",
+                width="clamp(20rem, 80vw, 100rem)",
             ),
             open=BacnetScanState.dialog_select_platform_open,
         ),
@@ -1576,6 +1631,27 @@ def proxy_down_warning() -> rx.Component:
         )
     )
 
+def device_scan_status() -> rx.Component:
+    return rx.fragment(
+            rx.foreach(
+                BacnetScanState.all_device_scan_point_status,
+                lambda status: rx.callout.root(
+                    rx.hstack(
+                        rx.callout.icon(rx.icon("info")),
+                        rx.vstack(
+                            rx.text(f"Scanning points on device: {status.object_name}"),
+                            rx.progress(
+                                value=status.percent_finished,
+                            ),
+                            rx.text(status.message, size="1"),
+                            width="100%"
+                        ),
+                        align="center"
+                    )
+                )
+            )
+        )
+
 def render() -> rx.Component:
     return (
         rx.box(
@@ -1613,8 +1689,9 @@ def render() -> rx.Component:
                             )
                         ),
                         rx.fragment(
-                            rx.button("click haha", on_click=BacnetScanState.set_it),
+                            # rx.button("click haha", on_click=BacnetScanState.set_it),
                             bacnet_scan_tool_header(),
+                            device_scan_status(),
                             proxy_down_warning(),
                             bacnet_networking_grid(),
                             bacnet_device_and_property_grid(),

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -79,43 +79,6 @@ def scan_for_devices_card():
         max_width="400px"
     )
 
-def card_with_no_devices():
-    return rx.box(
-        rx.box(
-            rx.text("Discovered Devices", size="5", weight="bold"),
-            rx.text("No devices discovered yet", color="gray"),
-            margin_bottom="1em",
-        ),
-        rx.box(
-            rx.box(
-                rx.table.root(
-                    rx.table.header(
-                        rx.table.row(
-                            rx.table.column_header_cell("Device Name"),
-                            rx.table.column_header_cell("Object ID"),
-                            rx.table.column_header_cell("IP Address"),
-                        )
-                    ),
-                    rx.table.body(
-                        rx.table.row(
-                            rx.table.cell(
-                                rx.text("No devices found. Run a scan to discover BACnet devices.", text_align="center", color="gray"),
-                                col_span=3,
-                            )
-                        )
-                    )
-                ),
-                height="300px",
-                overflow_y="auto",
-            ),
-        ),
-        border="1px solid",
-        border_color="grey",
-        border_radius=".5rem",
-        box_shadow="0 4px 12px rgba(0,0,0,0.08)",
-        padding="1.3rem",
-    )
-
 def true_writable_badge() -> rx.Component:
     return rx.badge(
         "TRUE",
@@ -191,7 +154,6 @@ def show_device_point(point: BACnetDevicePointModelView, index: int) -> rx.Compo
         rx.table.cell(point.units),
         rx.table.cell(point.notes),
     )
-
 
 def show_device(device: BACnetDeviceModelView, index: int) -> rx.Component:
     return rx.fragment(

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -2,10 +2,235 @@ import reflex as rx
 from ..state import BacnetScanState, ToolState, PlatformPageState
 from ..components.form_components import form_entry
 from ..components.tiles import platform_tile
+from ..components.buttons.tile_icon import tile_icon
 from ..layouts import app_layout_sidebar
 from ..model_views import BACnetDeviceModelView, BACnetDevicePointModelView
 
-def point_table_view_filter_dialog() -> rx.Component:
+def filter_badge(text: str, **props) -> rx.Component:
+    return rx.badge(
+        rx.hstack(
+            rx.icon("x", size=12),
+            rx.text(text),
+            spacing="1",
+            align="center"
+        ),
+        color_scheme="blue",
+        variant="surface",
+        cursor="pointer",
+        size="1",
+        **props
+    )
+
+def table_filter_trigger() -> rx.Component:
+    return tile_icon(
+        "search",
+    )
+
+def volttron_point_name_filter_popover() -> rx.Component:
+    return rx.popover.root(
+        rx.popover.trigger(
+            table_filter_trigger()
+        ),
+        rx.popover.content(
+            rx.form(
+                rx.vstack(
+                    form_entry.form_entry(
+                        "VOLTTRON Point Name Filter",
+                        rx.input(
+                            width="100%",
+                            name="units",
+                            default_value=BacnetScanState.point_table_filter.volttron_point_name,
+                        )
+                    ),
+                    rx.popover.close(
+                        rx.button(
+                            "Save",
+                            width="100%",
+                            type="submit"
+                        )
+                    )
+                ),
+                on_submit = BacnetScanState.filter_form_submit
+            )
+        ),
+    )
+
+def units_filter_popover() -> rx.Component:
+    return rx.popover.root(
+        rx.popover.trigger(
+            table_filter_trigger()
+        ),
+        rx.popover.content(
+            rx.form(
+                rx.vstack(
+                    form_entry.form_entry(
+                        "Units Filter",
+                        rx.input(
+                            width="100%",
+                            name="units",
+                            default_value=BacnetScanState.point_table_filter.units,
+                        )
+                    ),
+                    rx.popover.close(
+                        rx.button(
+                            "Save",
+                            width="100%",
+                            type="submit"
+                        )
+                    )
+                ),
+                on_submit = BacnetScanState.filter_form_submit
+            )
+        ),
+    )
+
+def object_type_filter_popover() -> rx.Component:
+    return rx.popover.root(
+        rx.popover.trigger(
+            table_filter_trigger()
+        ),
+        rx.popover.content(
+            rx.form(
+                rx.vstack(
+                    form_entry.form_entry(
+                        "BACnet Object Type Filter",
+                        rx.input(
+                            name="object_type",
+                            default_value=BacnetScanState.point_table_filter.object_type,
+                            width="100%"
+                        )
+                    ),
+                    rx.popover.close(
+                        rx.button(
+                            "Save",
+                            width="100%",
+                            type="submit"
+                        )
+                    )
+                ),
+                on_submit = BacnetScanState.filter_form_submit
+            )
+        ),
+    )
+
+def present_value_filter_popover() -> rx.Component:
+    return rx.popover.root(
+        rx.popover.trigger(
+            table_filter_trigger()
+        ),
+        rx.popover.content(
+            rx.form(
+                rx.vstack(
+                    form_entry.form_entry(
+                        "Present Value Filter",
+                        rx.input(
+                            name="present_value",
+                            default_value=BacnetScanState.point_table_filter.present_value,
+                            width="100%"
+                        )
+                    ),
+                    rx.popover.close(
+                        rx.button(
+                            "Save",
+                            width="100%",
+                            type="submit"
+                        )
+                    )
+                ),
+                on_submit = BacnetScanState.filter_form_submit
+            )
+        ),
+    )
+ 
+def writable_filter_popover() -> rx.Component:
+    return rx.popover.root(
+        rx.popover.trigger(
+            table_filter_trigger()
+        ),
+        rx.popover.content(
+            rx.form(
+                rx.vstack(
+                    form_entry.form_entry(
+                        "Writable Filter",
+                        rx.select(
+                            [" ", "TRUE", "FALSE"],
+                            name="writable",
+                            default_value=BacnetScanState.point_table_filter.writable,
+                            width="100%"
+                        )
+                    ),
+                    rx.popover.close(
+                        rx.button(
+                            "Save",
+                            width="100%",
+                            type="submit"
+                        )
+                    )
+                ),
+                on_submit = BacnetScanState.filter_form_submit
+            )
+        ),
+    )
+
+def index_filter_popover() -> rx.Component:
+    return rx.popover.root(
+        rx.popover.trigger(
+            table_filter_trigger()
+        ),
+        rx.popover.content(
+            rx.form(
+                rx.vstack(
+                    form_entry.form_entry(
+                        "Index Filter",
+                        rx.input(
+                            name="index",
+                            default_value=BacnetScanState.point_table_filter.index,
+                            width="100%"
+                        )
+                    ),
+                    rx.popover.close(
+                        rx.button(
+                            "Save",
+                            width="100%",
+                            type="submit"
+                        )
+                    )
+                ),
+                on_submit = BacnetScanState.filter_form_submit
+            )
+        ),
+    )
+
+def notes_filter_popover() -> rx.Component:
+    return rx.popover.root(
+        rx.popover.trigger(
+            table_filter_trigger()
+        ),
+        rx.popover.content(
+            rx.form(
+                rx.vstack(
+                    form_entry.form_entry(
+                        "Notes Filter",
+                        rx.input(
+                            name="notes",
+                            default_value=BacnetScanState.point_table_filter.notes,
+                            width="100%"
+                        )
+                    ),
+                    rx.popover.close(
+                        rx.button(
+                            "Save",
+                            width="100%",
+                            type="submit"
+                        )
+                    )
+                ),
+                on_submit = BacnetScanState.filter_form_submit
+            )
+        ),
+    )
+
+def point_column_filter_dialog() -> rx.Component:
     return rx.dialog.root(
             rx.dialog.trigger(
                 rx.button(
@@ -28,7 +253,7 @@ def point_table_view_filter_dialog() -> rx.Component:
                                 "Units",
                                 rx.vstack(
                                     rx.checkbox(
-                                        name="units", default_checked=BacnetScanState.point_table_filters.units
+                                        name="units", default_checked=BacnetScanState.point_column_filter.units
                                     ),
                                     justify="center",
                                     align="center",
@@ -39,7 +264,7 @@ def point_table_view_filter_dialog() -> rx.Component:
                                 "BACnet Object Type",
                                 rx.vstack(
                                     rx.checkbox(
-                                        name="object_type", default_checked=BacnetScanState.point_table_filters.object_type
+                                        name="object_type", default_checked=BacnetScanState.point_column_filter.object_type
                                     ),
                                     justify="center",
                                     align="center",
@@ -50,7 +275,7 @@ def point_table_view_filter_dialog() -> rx.Component:
                                 "Present Value",
                                 rx.vstack(
                                     rx.checkbox(
-                                        name="present_value", default_checked=BacnetScanState.point_table_filters.present_value
+                                        name="present_value", default_checked=BacnetScanState.point_column_filter.present_value
                                     ),
                                     justify="center",
                                     align="center",
@@ -61,7 +286,7 @@ def point_table_view_filter_dialog() -> rx.Component:
                                 "Writable",
                                 rx.vstack(
                                     rx.checkbox(
-                                        name="writable", default_checked=BacnetScanState.point_table_filters.writable
+                                        name="writable", default_checked=BacnetScanState.point_column_filter.writable
                                     ),
                                     justify="center",
                                     align="center",
@@ -72,7 +297,7 @@ def point_table_view_filter_dialog() -> rx.Component:
                                 "Index",
                                 rx.vstack(
                                     rx.checkbox(
-                                        name="index", default_checked=BacnetScanState.point_table_filters.index
+                                        name="index", default_checked=BacnetScanState.point_column_filter.index
                                     ),
                                     justify="center",
                                     align="center",
@@ -83,7 +308,7 @@ def point_table_view_filter_dialog() -> rx.Component:
                                 "Notes",
                                 rx.vstack(
                                     rx.checkbox(
-                                        name="notes", default_checked=BacnetScanState.point_table_filters.notes
+                                        name="notes", default_checked=BacnetScanState.point_column_filter.notes
                                     ),
                                     justify="center",
                                     align="center",
@@ -142,28 +367,130 @@ def device_point_dialog_table_headers() -> rx.Component:
 def device_point_table_headers() -> rx.Component:
     return rx.fragment(
         rx.cond(
-            BacnetScanState.point_table_filters.units,
-            rx.table.column_header_cell("Units")
+            BacnetScanState.point_column_filter.units,
+            rx.table.column_header_cell(
+                rx.hstack(
+                    rx.text("Units"),
+                    rx.hstack(
+                        units_filter_popover(),
+                        rx.cond(
+                            BacnetScanState.point_table_filter.units != "",
+                            filter_badge(
+                                BacnetScanState.point_table_filter.units,
+                                on_click=lambda: BacnetScanState.clear_point_filter("units"),
+                            )
+                        ),
+                        wrap="wrap"
+                    ),
+                    align="center",
+                    spacing="2"
+                )
+            )
         ),
         rx.cond(
-            BacnetScanState.point_table_filters.object_type,
-            rx.table.column_header_cell("BACnet Object Type")
+            BacnetScanState.point_column_filter.object_type,
+            rx.table.column_header_cell(
+                rx.hstack(
+                    rx.text("BACnet Object Type"),
+                    rx.hstack(
+                        object_type_filter_popover(),
+                        rx.cond(
+                            BacnetScanState.point_table_filter.object_type != "",
+                            filter_badge(
+                                BacnetScanState.point_table_filter.object_type,
+                                on_click=lambda: BacnetScanState.clear_point_filter("object_type"),
+                            )
+                        ),
+                        wrap="wrap"
+                    ),
+                    align="center",
+                    spacing="2"
+                )
+            )
         ),
         rx.cond(
-            BacnetScanState.point_table_filters.present_value,
-            rx.table.column_header_cell("Present Value")
+            BacnetScanState.point_column_filter.present_value,
+            rx.table.column_header_cell(
+                rx.hstack(
+                    rx.text("Present Value"),
+                    rx.hstack(
+                        present_value_filter_popover(),
+                        rx.cond(
+                            BacnetScanState.point_table_filter.present_value != "",
+                            filter_badge(
+                                BacnetScanState.point_table_filter.present_value,
+                                on_click=lambda: BacnetScanState.clear_point_filter("present_value"),
+                            )
+                        ),
+                        wrap="wrap"
+                    ),
+                    align="center",
+                    spacing="2"
+                )
+            )
         ),
         rx.cond(
-            BacnetScanState.point_table_filters.writable,
-            rx.table.column_header_cell("Writable")
+            BacnetScanState.point_column_filter.writable,
+            rx.table.column_header_cell(
+                rx.hstack(
+                    rx.text("Writable"),
+                    rx.hstack(
+                        writable_filter_popover(),
+                        rx.cond(
+                            BacnetScanState.point_table_filter.writable != "",
+                            filter_badge(
+                                BacnetScanState.point_table_filter.writable,
+                                on_click=lambda: BacnetScanState.clear_point_filter("writable"),
+                            )
+                        ),
+                        wrap="wrap"
+                    ),
+                    align="center",
+                    spacing="2"
+                )
+            )
         ),
         rx.cond(
-            BacnetScanState.point_table_filters.index,
-            rx.table.column_header_cell("Index")
+            BacnetScanState.point_column_filter.index,
+            rx.table.column_header_cell(
+                rx.hstack(
+                    rx.text("Index"),
+                    rx.hstack(
+                        index_filter_popover(),
+                        rx.cond(
+                            BacnetScanState.point_table_filter.index != "",
+                            filter_badge(
+                                BacnetScanState.point_table_filter.index,
+                                on_click=lambda: BacnetScanState.clear_point_filter("index"),
+                            )
+                        ),
+                        wrap="wrap"
+                    ),
+                    align="center",
+                    spacing="2"
+                )
+            )
         ),
         rx.cond(
-            BacnetScanState.point_table_filters.notes,
-            rx.table.column_header_cell("Notes"),
+            BacnetScanState.point_column_filter.notes,
+            rx.table.column_header_cell(
+                rx.hstack(
+                    rx.text("Notes"),
+                    rx.hstack(
+                        notes_filter_popover(),
+                        rx.cond(
+                            BacnetScanState.point_table_filter.notes != "",
+                            filter_badge(
+                                BacnetScanState.point_table_filter.notes,
+                                on_click=lambda: BacnetScanState.clear_point_filter("notes"),
+                            )
+                        ),
+                        wrap="wrap"
+                    ),
+                    align="center",
+                    spacing="2"
+                )
+            ),
         )
     )
 
@@ -590,19 +917,19 @@ def show_device_point(point: BACnetDevicePointModelView, index: int) -> rx.Compo
     return rx.table.row(
         volttron_point_name_cell(point, index),
         rx.cond(
-            BacnetScanState.point_table_filters.units,
+            BacnetScanState.point_column_filter.units,
             rx.table.cell(point.units)
         ),
         rx.cond(
-            BacnetScanState.point_table_filters.object_type,
+            BacnetScanState.point_column_filter.object_type,
             rx.table.cell(point.object_type)
         ),
         rx.cond(
-            BacnetScanState.point_table_filters.present_value,
+            BacnetScanState.point_column_filter.present_value,
             present_value_cell(point, index)
         ),
         rx.cond(
-            BacnetScanState.point_table_filters.writable,
+            BacnetScanState.point_column_filter.writable,
             rx.table.cell(
                 rx.cond(
                     point.writable,
@@ -612,11 +939,11 @@ def show_device_point(point: BACnetDevicePointModelView, index: int) -> rx.Compo
             )
         ),
         rx.cond(
-            BacnetScanState.point_table_filters.index,
+            BacnetScanState.point_column_filter.index,
             rx.table.cell(point.index)
         ),
         rx.cond(
-            BacnetScanState.point_table_filters.notes,
+            BacnetScanState.point_column_filter.notes,
             rx.table.cell(point.notes)
         ),
     )
@@ -659,7 +986,7 @@ def show_device(device: BACnetDeviceModelView, index: int) -> rx.Component:
                                 ),
                                 spacing="2"
                             ),
-                            point_table_view_filter_dialog(),
+                            point_column_filter_dialog(),
                             rx.hstack(
                                 export_points_dialog(),
                                 add_to_registry_config_file_dialog(),
@@ -673,12 +1000,17 @@ def show_device(device: BACnetDeviceModelView, index: int) -> rx.Component:
                                 rx.table.row(
                                     rx.table.column_header_cell(
                                         rx.hstack(
-                                            rx.checkbox(
-                                                checked=BacnetScanState.selected_device.select_all_points,
-                                                on_change=BacnetScanState.toggle_select_all_points
+                                            rx.hstack(
+                                                rx.checkbox(
+                                                    checked=BacnetScanState.selected_device.select_all_points,
+                                                    on_change=BacnetScanState.toggle_select_all_points
+                                                ),
+                                                rx.text("VOLTTRON Point Name", weight="bold"),
+                                                spacing="4"
                                             ),
-                                            rx.text("VOLTTRON Point Name", weight="bold"),
-                                            spacing="4"
+                                            volttron_point_name_filter_popover(),
+                                            align="center",
+                                            spacing="2"
                                         )
                                     ),
                                     device_point_table_headers(),
@@ -1248,6 +1580,7 @@ def render() -> rx.Component:
                             )
                         ),
                         rx.fragment(
+                            rx.button("click haha", on_click=BacnetScanState.set_it),
                             bacnet_scan_tool_header(),
                             proxy_down_warning(),
                             bacnet_networking_grid(),

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -1689,7 +1689,6 @@ def render() -> rx.Component:
                             )
                         ),
                         rx.fragment(
-                            # rx.button("click haha", on_click=BacnetScanState.set_it),
                             bacnet_scan_tool_header(),
                             device_scan_status(),
                             proxy_down_warning(),

--- a/volttron_installer/pages/platform_page.py
+++ b/volttron_installer/pages/platform_page.py
@@ -16,7 +16,7 @@ parts = Literal["connection", "instance_configuration"]
 @rx.page(route="/platform/[uid]", on_load=State.hydrate_state)
 def platform_page() -> rx.Component:
 
-    working_platform: Instance = State.platforms[State.current_uid]
+    # State.working_platform: Instance = State.platforms[State.current_uid]
 
     return rx.cond(
         State.is_hydrated, 
@@ -31,7 +31,7 @@ def platform_page() -> rx.Component:
                     ),
                     rx.text(f"""{
                             rx.cond(
-                                working_platform.new_instance,
+                                State.working_platform.new_instance,
                                 'New Platform',
                                 f'Platform: {State.platform_title}'
                             )
@@ -44,7 +44,7 @@ def platform_page() -> rx.Component:
                 ),
                 rx.hstack(
                     rx.cond(
-                        working_platform.new_instance==False,
+                        State.working_platform.new_instance==False,
                         icon_button_wrapper.icon_button_wrapper(
                             tool_tip_content="Copy Platform",
                             icon_key="copy",
@@ -110,14 +110,14 @@ def platform_page() -> rx.Component:
 # TODO: clean up these components to make it more readable and separated. 
 # These components all work if they have the right setup which follows:
 # def function() -> rx.Component:
-#   working_platform: Instance = State.platforms[State.current_uid]
+#   State.working_platform: Instance = State.platforms[State.current_uid]
 #   return rx.cond(State.is_hydrated,
 #             rest of component...
 #             )
 
 
 def platform_tabs() -> rx.Component:
-    working_platform: Instance = State.platforms[State.current_uid]
+    # State.working_platform: Instance = State.platforms[State.current_uid]
     return rx.cond(
         State.is_hydrated,
         rx.box(
@@ -125,7 +125,7 @@ def platform_tabs() -> rx.Component:
                 rx.tabs.list(
                     rx.tabs.trigger(
                         "Status", value="status", disabled=rx.cond(
-                            working_platform.platform.in_file,
+                            State.working_platform.platform.in_file,
                             False,
                             True
                         )
@@ -144,7 +144,7 @@ def platform_tabs() -> rx.Component:
                     value="configuration"
                 ),
                 default_value=rx.cond(
-                    working_platform.platform.in_file,
+                    State.working_platform.platform.in_file,
                     "status",
                     "configuration"
                 )
@@ -154,7 +154,7 @@ def platform_tabs() -> rx.Component:
 
 # Config tab and it's components:
 def configuration_tab_content() -> rx.Component:
-    working_platform: Instance = State.platforms[State.current_uid]
+    # State.working_platform: Instance = State.platforms[State.current_uid]
     
     return rx.cond(State.is_hydrated, 
             rx.box(
@@ -163,18 +163,18 @@ def configuration_tab_content() -> rx.Component:
                         header="Connection",
                         value="connection",
                         # content=rx.box(
-                        #     connection_accordion_content(working_platform)
+                        #     connection_accordion_content(State.working_platform)
                         # ),
                         content=rx.box(
                             rx.box(
                                 form_entry.form_entry(
                                     "Host",
                                     rx.input(
-                                        value= working_platform.host.ansible_host,
+                                        value= State.working_platform.host.ansible_host,
                                         on_change=lambda v: State.update_detail("id", v),
                                         size="3",
                                         required=True,
-                                        on_blur=lambda: State.determine_host_reachability(working_platform),
+                                        on_blur=lambda: State.determine_host_reachability(State.working_platform),
                                         color_scheme = rx.cond(
                                             State.is_host_resolvable,
                                             "gray",
@@ -210,7 +210,7 @@ def configuration_tab_content() -> rx.Component:
                                 form_entry.form_entry(
                                     "Username",
                                     rx.input(
-                                        value= working_platform.host.ansible_user,
+                                        value= State.working_platform.host.ansible_user,
                                         on_change=lambda v: State.update_detail("ansible_user", v),
                                         size="3",
                                         required=True,
@@ -224,7 +224,7 @@ def configuration_tab_content() -> rx.Component:
                                 form_entry.form_entry(
                                     "Port SSH",
                                     rx.input(
-                                        value= working_platform.host.ansible_port,
+                                        value= State.working_platform.host.ansible_port,
                                         on_change=lambda v: State.update_detail("ansible_port", v),
                                         size="3",
                                         required=True,
@@ -242,7 +242,7 @@ def configuration_tab_content() -> rx.Component:
                                     rx.hstack(
                                         rx.text("Toggle Advanced"),
                                         rx.cond(
-                                            working_platform.advanced_expanded,
+                                            State.working_platform.advanced_expanded,
                                             rx.icon("chevron-up"),
                                             rx.icon("chevron-down")
                                         )
@@ -251,12 +251,12 @@ def configuration_tab_content() -> rx.Component:
                                     on_click=lambda: State.toggle_advanced(State.current_uid)
                                 ),
                                 rx.cond(
-                                    working_platform.advanced_expanded,
+                                    State.working_platform.advanced_expanded,
                                     rx.fragment(
                                         form_entry.form_entry(
                                             "HTTP Proxy",
                                             rx.input(
-                                                value= working_platform.host.http_proxy,
+                                                value= State.working_platform.host.http_proxy,
                                                 on_change=lambda v: State.update_detail("http_proxy", v),
                                                 size="3",
                                                 required=True,
@@ -265,7 +265,7 @@ def configuration_tab_content() -> rx.Component:
                                         form_entry.form_entry(
                                             "HTTPS Proxy",
                                             rx.input(
-                                                value= working_platform.host.https_proxy,
+                                                value= State.working_platform.host.https_proxy,
                                                 on_change=lambda v: State.update_detail("https_proxy", v),
                                                 size="3",
                                                 required=True,
@@ -274,7 +274,7 @@ def configuration_tab_content() -> rx.Component:
                                         form_entry.form_entry(
                                             "VOLTTRON Home",
                                             rx.input(
-                                                value= working_platform.host.volttron_home,
+                                                value= State.working_platform.host.volttron_home,
                                                 on_change=lambda v: State.update_detail("volttron_home", v),
                                                 size="3",
                                                 required=True,
@@ -291,7 +291,7 @@ def configuration_tab_content() -> rx.Component:
                         header="Instance Configuration",
                         value="instance_configuration",
                         # content=rx.box(
-                        #     instance_configuration_accordion_content(working_platform)
+                        #     instance_configuration_accordion_content(State.working_platform)
                         # ),
                         content=rx.box(
                             rx.box(
@@ -300,7 +300,7 @@ def configuration_tab_content() -> rx.Component:
                                     rx.vstack(
                                         rx.input(
                                             size="3",
-                                            value=working_platform.platform.config.instance_name,
+                                            value=State.working_platform.platform.config.instance_name,
                                             on_change=lambda v: State.update_platform_config_detail("instance_name", v),
                                             required=True,
                                         ),
@@ -333,7 +333,7 @@ def configuration_tab_content() -> rx.Component:
                                     rx.vstack(
                                         rx.input(
                                             size="3",
-                                            value=working_platform.platform.config.vip_address,
+                                            value=State.working_platform.platform.config.vip_address,
                                             on_change=lambda v: State.update_platform_config_detail("vip_address", v),
                                             required=True,
                                         ),  
@@ -369,7 +369,7 @@ def configuration_tab_content() -> rx.Component:
                                     rx.vstack(
                                         rx.checkbox(
                                             size="3",
-                                            checked=working_platform.web_checked,
+                                            checked=State.working_platform.web_checked,
                                             on_change=lambda: State.toggle_web()
                                         ),
                                         justify="center",
@@ -378,13 +378,13 @@ def configuration_tab_content() -> rx.Component:
                                     )
                                 ),
                                 rx.cond(
-                                    working_platform.web_checked,
+                                    State.working_platform.web_checked,
                                     rx.fragment(
                                         form_entry.form_entry(
                                             "Web Bind Address",
                                             rx.input(
                                                 size="3",
-                                                value=working_platform.web_bind_address,
+                                                value=State.working_platform.web_bind_address,
                                                 on_change=lambda v: State.update_platform_config_detail("web_bind_address", v),
                                                 required=True,
                                             )
@@ -395,7 +395,7 @@ def configuration_tab_content() -> rx.Component:
                                     rx.hstack(
                                         rx.text("Agent Configuration"),
                                         rx.cond(
-                                            working_platform.agent_configuration_expanded,
+                                            State.working_platform.agent_configuration_expanded,
                                             rx.icon("chevron-up"),
                                             rx.icon("chevron-down")
                                         )
@@ -405,7 +405,7 @@ def configuration_tab_content() -> rx.Component:
                                 ),
                                 rx.box(
                                     rx.cond(
-                                        working_platform.agent_configuration_expanded,
+                                        State.working_platform.agent_configuration_expanded,
                                         rx.el.div(
                                             rx.box(
                                                 rx.box(
@@ -416,9 +416,9 @@ def configuration_tab_content() -> rx.Component:
                                                             agent.identity,
                                                             right_component=tile_icon(
                                                                 "plus",
-                                                                on_click=State.handle_adding_agent(agent)
-                                                                ),
+                                                                on_click=lambda: State.handle_adding_agent(agent, State.current_uid)
                                                             ),
+                                                        ),
                                                     ),
                                                     class_name="agent_config_view_content"
                                                 ),
@@ -427,8 +427,9 @@ def configuration_tab_content() -> rx.Component:
                                             rx.box(
                                                 rx.box(
                                                     rx.heading("Added Agents", as_="h3"),
+                                                    rx.text(f"agents: {State.raka}"),
                                                     rx.foreach(
-                                                        working_platform.platform.agents,
+                                                        State.working_platform.platform.agents,
                                                         lambda identity_agent_pair: config_tile.config_tile(
                                                             identity_agent_pair[1].identity,
                                                             left_component=tile_icon(
@@ -486,7 +487,7 @@ def configuration_tab_content() -> rx.Component:
                         disabled=rx.cond(
                             (State.instance_savable)
                             & (State.instance_uncaught),
-                            # (working_platform.uncaught),
+                            # (State.working_platform.uncaught),
                             False,
                             True
                         )
@@ -561,7 +562,7 @@ def configuration_tab_content() -> rx.Component:
                             on_click=lambda: State.handle_cancel(),
                             disabled=rx.cond(
                                 State.instance_uncaught == False,
-                                # working_platform.uncaught == False,
+                                # State.working_platform.uncaught == False,
                                 True,
                                 False
                             )

--- a/volttron_installer/pages/platform_page.py
+++ b/volttron_installer/pages/platform_page.py
@@ -427,7 +427,6 @@ def configuration_tab_content() -> rx.Component:
                                             rx.box(
                                                 rx.box(
                                                     rx.heading("Added Agents", as_="h3"),
-                                                    rx.text(f"agents: {State.raka}"),
                                                     rx.foreach(
                                                         State.working_platform.platform.agents,
                                                         lambda identity_agent_pair: config_tile.config_tile(

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -2211,14 +2211,19 @@ class BacnetScanState(rx.State):
 
     @rx.event
     def filter_form_submit(self, form_data: dict):
+        # Start with the current filter values
+        current_filter = self.point_table_filter
+        
+        # Create a new filter object preserving all existing values
         self.point_table_filter = BACnetPointTableFilter(
-            volttron_point_name=form_data.get("volttron_point_name", ""),
-            units=form_data.get("units", ""),
-            object_type=form_data.get("object_type", ""),
-            writable=form_data.get("writable", "").strip(),
-            present_value=form_data.get("present_value", ""),
-            index=form_data.get("index", ""),
-            notes=form_data.get("notes", "")
+            # For each field, use the form data if provided, otherwise keep existing value
+            volttron_point_name=form_data.get("volttron_point_name", current_filter.volttron_point_name),
+            units=form_data.get("units", current_filter.units),
+            object_type=form_data.get("object_type", current_filter.object_type),
+            writable=form_data.get("writable", current_filter.writable).strip() if form_data.get("writable") is not None else current_filter.writable,
+            present_value=form_data.get("present_value", current_filter.present_value),
+            index=form_data.get("index", current_filter.index),
+            notes=form_data.get("notes", current_filter.notes)
         )
 
     @rx.event

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -1567,7 +1567,7 @@ def __create_prefilled_bacnet_device__() -> BACnetDeviceModelView:
         BACnetDevicePointModelView(
             device_name="Building1AHU1",
             volttron_point_name="ZoneTemp1",
-            writable=True,
+            writable=False,
             object_type="analogValue",
             present_value="72.5",
             units="degF",

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -1603,62 +1603,62 @@ class BacnetScanState(rx.State):
     windows_host_ip_info: WindowsHostIPModel = WindowsHostIPModel()
 
     # For bacnet point stuff
-    writable_map = {
-        0: False,  # analog-input
-        1: True,   # analog-output
-        2: False,  # analog-value (temporarily set to False, but these are typically writable)
-        3: False,  # binary-input
-        4: True,   # binary-output
-        5: False,  # binary-value (temporarily set to False, but these are typically writable)
-        6: True,   # calendar
-        7: True,   # command
-        8: False,  # device
-        9: True,   # event-enrollment
-        10: True,  # file
-        11: True,  # group
-        12: True,  # loop
-        13: False, # multi-state-input
-        14: True,  # multi-state-output
-        15: True,  # notification-class
-        16: True,  # program
-        17: True,  # schedule
-        18: False, # averaging
-        19: False, # multi-state-value (temporarily set to False, but these are typically writable)
-        20: False, # trend-log
-        21: False, # life-safety-point
-        22: False, # life-safety-zone
-        23: False, # accumulator
-        24: False, # pulse-converter
-        25: False, # event-log
-        26: True,  # global-group
-        27: False, # trend-log-multiple
-        28: True,  # load-control
-        29: False, # structured-view
-        30: True,  # access-door
-        31: False, # unassigned
-        32: False, # access-credential
-        33: False, # access-point
-        34: True,  # access-rights
-        35: False, # access-user
-        36: False, # access-zone
-        37: False, # credentional-data-input
-        38: False, # network-security (removed)
-        39: False, # bitstring-value (temporarily set to False, but these are typically writable)
-        40: False, # characterstring-value (temporarily set to False, but these are typically writable)
-        41: False, # date-pattern-value (temporarily set to False, but these are typically writable)
-        42: False, # date-value (temporarily set to False, but these are typically writable)
-        43: False, # datetime-pattern-value (temporarily set to False, but these are typically writable)
-        44: False, # datetime-value (temporarily set to False, but these are typically writable)
-        45: False, # integer-value (temporarily set to False, but these are typically writable)
-        46: False, # large-analog-value (temporarily set to False, but these are typically writable)
-        47: False, # octetstring-value (temporarily set to False, but these are typically writable)
-        48: False, # positive-integer-value (temporarily set to False, but these are typically writable)
-        49: False, # time-pattern-value (temporarily set to False, but these are typically writable)
-        50: False, # time-value (temporarily set to False, but these are typically writable)
-        51: True,  # notification-forwarder
-        52: True,  # alert-enrollment
-        53: True,  # channel
-        54: True,  # lighting-output
+    writable_map: Dict[int, BACnetObjectType] = {
+        0: BACnetObjectType(value=0, type_name="analog-input", writable=False),
+        1: BACnetObjectType(value=1, type_name="analog-output", writable=True),
+        2: BACnetObjectType(value=2, type_name="analog-value", writable=False),
+        3: BACnetObjectType(value=3, type_name="binary-input", writable=False),
+        4: BACnetObjectType(value=4, type_name="binary-output", writable=True),
+        5: BACnetObjectType(value=5, type_name="binary-value", writable=False),
+        6: BACnetObjectType(value=6, type_name="calendar", writable=True),
+        7: BACnetObjectType(value=7, type_name="command", writable=True),
+        8: BACnetObjectType(value=8, type_name="device", writable=False),
+        9: BACnetObjectType(value=9, type_name="event-enrollment", writable=True),
+        10: BACnetObjectType(value=10, type_name="file", writable=True),
+        11: BACnetObjectType(value=11, type_name="group", writable=True),
+        12: BACnetObjectType(value=12, type_name="loop", writable=True),
+        13: BACnetObjectType(value=13, type_name="multi-state-input", writable=False),
+        14: BACnetObjectType(value=14, type_name="multi-state-output", writable=True),
+        15: BACnetObjectType(value=15, type_name="notification-class", writable=True),
+        16: BACnetObjectType(value=16, type_name="program", writable=True),
+        17: BACnetObjectType(value=17, type_name="schedule", writable=True),
+        18: BACnetObjectType(value=18, type_name="averaging", writable=False),
+        19: BACnetObjectType(value=19, type_name="multi-state-value", writable=False),
+        20: BACnetObjectType(value=20, type_name="trend-log", writable=False),
+        21: BACnetObjectType(value=21, type_name="life-safety-point", writable=False),
+        22: BACnetObjectType(value=22, type_name="life-safety-zone", writable=False),
+        23: BACnetObjectType(value=23, type_name="accumulator", writable=False),
+        24: BACnetObjectType(value=24, type_name="pulse-converter", writable=False),
+        25: BACnetObjectType(value=25, type_name="event-log", writable=False),
+        26: BACnetObjectType(value=26, type_name="global-group", writable=True),
+        27: BACnetObjectType(value=27, type_name="trend-log-multiple", writable=False),
+        28: BACnetObjectType(value=28, type_name="load-control", writable=True),
+        29: BACnetObjectType(value=29, type_name="structured-view", writable=False),
+        30: BACnetObjectType(value=30, type_name="access-door", writable=True),
+        31: BACnetObjectType(value=31, type_name="unassigned", writable=False),
+        32: BACnetObjectType(value=32, type_name="access-credential", writable=False),
+        33: BACnetObjectType(value=33, type_name="access-point", writable=False),
+        34: BACnetObjectType(value=34, type_name="access-rights", writable=True),
+        35: BACnetObjectType(value=35, type_name="access-user", writable=False),
+        36: BACnetObjectType(value=36, type_name="access-zone", writable=False),
+        37: BACnetObjectType(value=37, type_name="credentional-data-input", writable=False),
+        38: BACnetObjectType(value=38, type_name="network-security", writable=False),
+        39: BACnetObjectType(value=39, type_name="bitstring-value", writable=False),
+        40: BACnetObjectType(value=40, type_name="characterstring-value", writable=False),
+        41: BACnetObjectType(value=41, type_name="date-pattern-value", writable=False),
+        42: BACnetObjectType(value=42, type_name="date-value", writable=False),
+        43: BACnetObjectType(value=43, type_name="datetime-pattern-value", writable=False),
+        44: BACnetObjectType(value=44, type_name="datetime-value", writable=False),
+        45: BACnetObjectType(value=45, type_name="integer-value", writable=False),
+        46: BACnetObjectType(value=46, type_name="large-analog-value", writable=False),
+        47: BACnetObjectType(value=47, type_name="octetstring-value", writable=False),
+        48: BACnetObjectType(value=48, type_name="positive-integer-value", writable=False),
+        49: BACnetObjectType(value=49, type_name="time-pattern-value", writable=False),
+        50: BACnetObjectType(value=50, type_name="time-value", writable=False),
+        51: BACnetObjectType(value=51, type_name="notification-forwarder", writable=True),
+        52: BACnetObjectType(value=52, type_name="alert-enrollment", writable=True),
+        53: BACnetObjectType(value=53, type_name="channel", writable=True),
+        54: BACnetObjectType(value=54, type_name="lighting-output", writable=True),
     }
 
     # important event, actually spins up the tool when the page loads.
@@ -1726,14 +1726,13 @@ class BacnetScanState(rx.State):
         # Update filters based on form data
         filters = {
             "units": form_data.get("units") == "on",
+            "object_type": form_data.get("object_type") == "on",
             "present_value": form_data.get("present_value") == "on",
             "writable": form_data.get("writable") == "on",
             "index": form_data.get("index") == "on",
             "notes": form_data.get("notes") == "on",
         }
-        logger.debug(f"Checkbox filters: {filters}")
         self.point_table_filters=BACnetPointFilters(**filters)
-        logger.debug(f"this is our table filters now: {self.point_table_filters}")
 
     @rx.var
     def warn_ping_range(self) -> bool: 
@@ -2167,10 +2166,10 @@ class BacnetScanState(rx.State):
                         )
                     if res.get("status") == "error":
                         logger.debug(f"this is our res: {res}")
-                        raise Exception(f"Error occured calling api though thin endpoint wrapper")
+                        raise Exception(f"Error occurred calling api though thin endpoint wrapper")
                 except Exception as e:
                     import traceback
-                    logger.debug(f"An error occured running scan: {traceback.format_exc()}")
+                    logger.debug(f"An error occurred running scan: {traceback.format_exc()}")
                     break
 
                 points: list = res["properties"]["object-list"]
@@ -2183,7 +2182,7 @@ class BacnetScanState(rx.State):
                     object_identifier: str = f"{obj[0]},{obj[1]}"
                     logger.debug(f"Created object_identifier: {object_identifier}")
                     
-                    writable: bool = self.writable_map[obj[0]]
+                    writable: bool = self.writable_map[obj[0]].writable
                     logger.debug(f"Object type {obj[0]} is writable: {writable}")
                     
                     # Getting point name
@@ -2251,42 +2250,45 @@ class BacnetScanState(rx.State):
                         logger.debug(f"Notes value extracted: {notes_value}")
                     except Exception as e:
                         logger.error(f"Failed to get notes value: {e}")
-                        notes_value = "N/A"
+                        notes_value = ""
                         logger.debug(f"Using default notes value: {notes_value}")
 
                     logger.debug(f"Step 5: Getting index for {object_identifier} at {device.scanned_ip_target}")
                     try:
-                        index_value_response = await read_bacnet_property(
-                            BACnetReadPropertyRequest(
-                                device_address=device.scanned_ip_target,
-                                object_identifier=object_identifier,
-                                property_identifier="index"
-                            ),
-                            timeout=4.0
-                        )
-                        logger.debug(f"Index value response received: {index_value_response}")
-                        index_value = notes_value_response["result"]["_value"]
+                        index_value = obj[1]
+                        logger.debug(f"Index value response received: {index_value}")
                         logger.debug(f"Index value extracted: {index_value}")
                     except Exception as e:
                         logger.error(f"Failed to get index value: {e}")
                         index_value = "N/A"
                         logger.debug(f"Using default index value: {index_value}")
 
+                    logger.debug(f"Step 6: Getting object type for {object_identifier} at {device.scanned_ip_target}")
+                    try:
+                        object_type = self.writable_map[obj[0]].type_name
+                        logger.debug(f"Index value response received: {object_type}")
+                        logger.debug(f"Index value extracted: {object_type}")
+                    except Exception as e:
+                        logger.error(f"Failed to get index value: {e}")
+                        object_type = "N/A"
+                        logger.debug(f"Using default index value: {object_type}")
+
 
                     # Create and add the point to device
-                    logger.debug(f"Step 6: Creating point model for {point_name}")
+                    logger.debug(f"Step 7: Creating point model for {point_name}")
                     point = BACnetDevicePointModelView(
                         device_name=point_name,
                         writable=writable,
                         present_value=present_value,
                         units=units,
                         notes=notes_value,
-                        index=index_value
+                        index=index_value,
+                        object_type=object_type
                     )
                     point.safe_point = point.to_dict()
                     logger.debug(f"Point created: {point}")
                     
-                    logger.debug(f"Step 7: Adding point to device {device}")
+                    logger.debug(f"Step 8: Adding point to device {device}")
                     device.points.append(point)
                     logger.debug(f"Point added to device successfully. Device now has {len(device.points)} points.")
 
@@ -2358,7 +2360,64 @@ class BacnetScanState(rx.State):
         except Exception as e:
             logger.debug(f"There was an error getting local ip info {e}")
 
-    # Resetting methods:
+    # Exporting
+    @rx.event
+    def export_to_csv(self):
+        csv_data = self._convert_selected_points_to_csv()
+
+        escaped_csv_data = csv_data.replace("'", "\\'")  # Escape single quotes in CSV content
+        
+        # JavaScript code for invoking the "Save As" dialog
+        js_code = f"""
+            if (window.showSaveFilePicker) {{
+                // Use File System Access API for explicit Save As dialog
+                async function saveFile() {{
+                    try {{
+                        const options = {{
+                            types: [{{
+                                description: 'CSV file',
+                                accept: {{
+                                    'text/csv': ['.csv']
+                                }}
+                            }}]
+                        }};
+                        const fileHandle = await window.showSaveFilePicker(options);
+                        const writable = await fileHandle.createWritable();
+                        await writable.write(`{escaped_csv_data}`);
+                        await writable.close();
+                        return true;  // Indicate success
+                    }} catch (err) {{
+                        // Check if this is an abort error (user canceled)
+                        if (err.name === 'AbortError') {{
+                            console.log('User canceled the save dialog');
+                            return false;  // User canceled
+                        }} else {{
+                            console.error('Save As failed:', err);
+                            return false;  // Other error
+                        }}
+                    }}
+                }}
+                
+                saveFile();  // We don't need to catch here as we already handle errors inside
+            }} else {{
+                // Fallback to Blob saving
+                try {{
+                    const blob = new Blob([`{escaped_csv_data}`], {{ type: 'text/csv;charset=utf-8' }});
+                    const link = document.createElement('a');
+                    link.href = URL.createObjectURL(blob);
+                    link.download = 'bacnet_points.csv';
+                    document.body.appendChild(link);
+                    link.click();
+                    document.body.removeChild(link);
+                    URL.revokeObjectURL(link.href);
+                }} catch (err) {{
+                    console.error('Fallback save method failed:', err);
+                }}
+            }}
+        """
+        return rx.call_script(js_code)
+
+    # Resetting methods
     @rx.event
     def reset_point_table_filters(self):
         self.point_table_filters = BACnetPointFilters()
@@ -2403,3 +2462,36 @@ class BacnetScanState(rx.State):
         
         # logger.debug(f"Final absolute_index: {absolute_index}")
         return absolute_index
+    
+    def _convert_selected_points_to_csv(self) -> str:
+        """Convert selected_points to CSV string with mapped column names."""
+        # Define the CSV columns and their mapping to model fields
+        columns = [
+            ("VOLTTRON Point Name", "device_name"),
+            ("Units", "units"),
+            ("BACnet Object Type", "object_type"),
+            ("Property", "present_value"),
+            ("Writable", "writable"),
+            ("Index", "index"),
+            ("Notes", "notes"),
+        ]
+        fieldnames = [field for _, field in columns]
+        header = [col for col, _ in columns]
+
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(header)
+
+        for point in self.selected_points:
+            point_dict = point.dict() if hasattr(point, "dict") else point.__dict__
+            row = []
+            for _, field in columns:
+                value = point_dict.get(field, "")
+                if isinstance(value, bool):
+                    value = "TRUE" if value else "FALSE"
+                row.append(value)
+            writer.writerow(row)
+
+        csv_data = output.getvalue()
+        output.close()
+        return csv_data

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -2072,7 +2072,6 @@ class BacnetScanState(rx.State):
     def cancel_device_point_present_value_edit(self, index: int):
         absolute_index = self.get_absolute_index(index)
         yield BacnetScanState.disable_device_point_present_value_edit(index)
-        logger.debug(f"this is the safe point: {self.selected_device.points[absolute_index].safe_point}")
         yield
         self.selected_device.points[absolute_index].present_value = self.selected_device.points[absolute_index].safe_point['present_value']
         yield
@@ -2081,7 +2080,6 @@ class BacnetScanState(rx.State):
     def save_device_point_present_value_edit(self, index: int):
         absolute_index = self.get_absolute_index(index)
         yield BacnetScanState.disable_device_point_present_value_edit(index)
-        logger.debug(f"this is the safe point: {self.selected_device.points[absolute_index].safe_point}")
         yield
         self.selected_device.points[absolute_index].safe_point = self.selected_device.points[absolute_index].to_dict()
         yield

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -2661,25 +2661,9 @@ class BacnetScanState(rx.State):
         if not self.proxy_up:
             yield rx.toast.error("Proxy must be started first.")
             return
-        identfier = point.write_request_target.get("object_identifier", "")
-        if identfier != "analog-value,3000112":
-            logger.debug(f"We cant continue. point is not safe to write: {identfier}")
-            return
-    
-        try:
-            val = float(value)
-            if 69 <= val <= 76:
-                logger.debug(f"we are valid to write: {val}")
-                value = val
-            else:
-                logger.debug(f"value is not in range to write for the point.")
-                value = 71
-                return
-        except Exception as e:
-            logger.error(f"{e}")
-            value = 71
-            
+
         yield rx.toast.info(f"Writing to property on {self.write_property.device_address}")
+        logger.debug(f"Writing `{property_identifier}` with value: `{value}` on address: `{self.write_property.device_address}`")
 
         try:
             logger.debug(f"Writing bacnet property: {property_identifier}, to target: {point.write_request_target}, value: {value}")

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -2814,8 +2814,28 @@ class BacnetScanState(rx.State):
         config_entry = self._create_config_store_entry(path, csv_value, component_id)
         driver_agent.config_store.append(config_entry)
         
-        # Finalize the agent
-        # driver_agent.is_new = False
+        # Save the config store entry
+
+        # NOTE: This is largely a copy and paste job from AgentConfigState.save_config_store_entry
+        # TODO: make the function referenced above more modular and not tied to AgentConfigState variables
+        list_of_config_paths: list[tuple[str, str]] = [
+            (entry_.safe_entry["path"], entry_.component_id) for entry_ in driver_agent.config_store
+        ]
+        # Check if the path exists and belongs to a different component
+        for path, component_id in list_of_config_paths:
+            if config_entry.path == "" or (config_entry.path == path and config_entry.component_id != component_id):
+                # This check catches all empty paths or duplicate paths
+                yield rx.toast.error(f"Config path is already in use.")
+                return
+        config_entry.safe_entry = config_entry.dict()
+        logger.debug(f"this is the config_entry's safe dict: {config_entry.safe_entry}")
+        config_entry.uncommitted=False
+        logger.debug(f"going through the agent's config store, here they are:")
+        for driver_agent_config in driver_agent.config_store:
+            logger.debug(f"safe dict: {driver_agent_config.safe_entry}")
+
+        # Finalize and save the agent
+        driver_agent.is_new = False
         driver_agent.safe_agent = driver_agent.to_dict()
         
         # Update the platform state

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -1559,8 +1559,6 @@ class IndexPageState(rx.State):
             self.selected_tool = tool
         logger.debug(f"Selected tool changed to: {self.selected_tool}")
 
-
-
 def __create_prefilled_bacnet_device__() -> BACnetDeviceModelView:
     # Create 5 point model views
     points = [
@@ -1663,7 +1661,6 @@ def __create_prefilled_bacnet_device__() -> BACnetDeviceModelView:
     
     return device
 
-
 class BacnetScanState(rx.State):
     selected_property_tab: Literal["read", "write"] = "read"  # Default to "read" tab
     discovered_devices: list[BACnetDeviceModelView] = []  # Store discovered devices
@@ -1694,6 +1691,7 @@ class BacnetScanState(rx.State):
     # Dialog States
     dialog_registry_open: bool = False
     dialog_select_platform_open: bool = False
+    selected_platform_uid: str = ""
 
     # Fields
     proxy_field_value: str = ""
@@ -2012,6 +2010,7 @@ class BacnetScanState(rx.State):
 
     @rx.event
     def close_dialogs(self):
+        self.selected_platform_uid = ""
         self.dialog_registry_open = False
         self.dialog_select_platform_open = False
 
@@ -2697,6 +2696,11 @@ class BacnetScanState(rx.State):
             yield rx.toast.success("Retrieved Host IP")
         except Exception as e:
             logger.debug(f"There was an error getting local ip info {e}")
+
+    # Other
+    @rx.event
+    def select_platform_for_registry_config(self, uid: str):
+        self.selected_platform_uid = uid if self.selected_platform_uid != uid else ""
 
     # Exporting
     @rx.event

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -1894,6 +1894,29 @@ class BacnetScanState(rx.State):
         """Handle input change for the main IP address field."""
         self.ip_address = value
 
+    # Handle Device Point editing
+    @rx.event
+    def handle_present_value_edit(self, index: int, value: str):
+        self.selected_device.points[index].present_value = value
+
+    @rx.event
+    def enable_device_point_present_value_edit(self, index: int):
+        self.selected_device.points[index].present_value_editing = True
+    
+    @rx.event
+    def disable_device_point_present_value_edit(self, index: int):
+        self.selected_device.points[index].present_value_editing = False
+
+    @rx.event
+    def cancel_device_point_present_value_edit(self, index: int):
+        self.selected_device.points[index].present_value = self.selected_device.points[index].safe_point["present_value"]
+        yield BacnetScanState.disable_device_point_present_value_edit(index)
+
+    @rx.event
+    def save_device_point_present_value_edit(self, index: int):
+        self.selected_device.points[index].safe_point = self.selected_device.points[index].to_dict()
+        yield BacnetScanState.disable_device_point_present_value_edit(index)
+        # yield method to write to point
 
     # Handle the actual endpoint actions/functionality
     @rx.event
@@ -2056,6 +2079,7 @@ class BacnetScanState(rx.State):
                         units=units,
                         notes=notes_value
                     )
+                    point.safe_point = point.to_dict()
                     logger.debug(f"Point created: {point}")
                     
                     logger.debug(f"Step 5: Adding point to device {device}")

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -7,7 +7,7 @@ from .utils.conversion_methods import json_string_to_csv_string, csv_string_to_j
 from .utils.validate_content import check_json, check_csv, check_path, check_yaml, check_regular_expression
 from .utils.create_csv_string import create_csv_string, create_and_validate_csv_string
 from .navigation.state import NavigationState
-from .backend.models import AgentType, HostEntry, PlatformConfig, PlatformDefinition, ConfigStoreEntry, AgentDefinition, CreatePlatformRequest, CreateOrUpdateHostEntryRequest, ToolRequest, BACnetDevice
+from .backend.models import AgentType, HostEntry, PlatformConfig, PlatformDefinition, ConfigStoreEntry, AgentDefinition, CreatePlatformRequest, CreateOrUpdateHostEntryRequest, ToolRequest, BACnetDevice, BACnetWritePropertyRequest
 from .utils.create_component_uid import generate_unique_uid
 from .utils.conversion_methods import csv_string_to_usable_dict
 from .utils.validate_content import check_json
@@ -1587,6 +1587,10 @@ class BacnetScanState(rx.State):
     _selected_points_per_page_limit: int = 15
     _selected_points_page_number: int = 1
 
+    # Dialog States
+    dialog_registry_open: bool = False
+    dialog_select_platform_open: bool = False
+
     # Fields
     proxy_field_value: str = ""
 
@@ -1725,6 +1729,7 @@ class BacnetScanState(rx.State):
     def save_point_table_filters(self, form_data: dict):
         # Update filters based on form data
         filters = {
+            "volttron_point_name": form_data.get("volttron_point_name") == "on",
             "units": form_data.get("units") == "on",
             "object_type": form_data.get("object_type") == "on",
             "present_value": form_data.get("present_value") == "on",
@@ -1863,6 +1868,22 @@ class BacnetScanState(rx.State):
         """Go to a specific page of selected points."""
         if 1 <= page <= self.selected_points_total_pages:
             self._selected_points_page_number = page
+    
+    # Dialog events
+    @rx.event
+    def open_registry_dialog(self):
+        self.dialog_registry_open = True
+        self.dialog_select_platform_open = False
+
+    @rx.event
+    def open_select_platform_dialog(self):
+        self.dialog_registry_open = False
+        self.dialog_select_platform_open = True
+
+    @rx.event
+    def close_dialogs(self):
+        self.dialog_registry_open = False
+        self.dialog_select_platform_open = False
 
     @rx.event
     def on_selected_points_dialog_close(self):
@@ -2099,7 +2120,45 @@ class BacnetScanState(rx.State):
         yield
         self.selected_device.points[absolute_index].safe_point = self.selected_device.points[absolute_index].to_dict()
         yield
-        # yield method to write to point
+        yield BacnetScanState.handle_write_property(
+            self.selected_device.points[absolute_index],
+            "present-value",
+            self.selected_device.points[absolute_index].safe_point["present_value"],
+            1
+        )
+
+
+    @rx.event
+    def handle_volttron_point_name_value_edit(self, index: int, value: str):
+        index = self.get_absolute_index(index)
+        self.selected_device.points[index].volttron_point_name = value
+
+    @rx.event
+    def enable_device_point_volttron_point_name_value_edit(self, index: int):
+        index = self.get_absolute_index(index)
+        self.selected_device.points[index].volttron_point_name_editing = True
+    
+    @rx.event
+    def disable_device_point_volttron_point_name_value_edit(self, index: int):
+        index = self.get_absolute_index(index)
+        self.selected_device.points[index].volttron_point_name_editing = False
+
+    @rx.event
+    def cancel_device_point_volttron_point_name_value_edit(self, index: int):
+        absolute_index = self.get_absolute_index(index)
+        yield BacnetScanState.disable_device_point_volttron_point_name_value_edit(index)
+        yield
+        self.selected_device.points[absolute_index].volttron_point_name = self.selected_device.points[absolute_index].safe_point['volttron_point_name']
+        yield
+
+    @rx.event
+    def save_device_point_volttron_point_name_value_edit(self, index: int):
+        absolute_index = self.get_absolute_index(index)
+        yield BacnetScanState.disable_device_point_volttron_point_name_value_edit(index)
+        yield
+        self.selected_device.points[absolute_index].safe_point = self.selected_device.points[absolute_index].to_dict()
+        yield
+
 
     # Handle the actual endpoint actions/functionality
     @rx.event
@@ -2141,7 +2200,6 @@ class BacnetScanState(rx.State):
             yield rx.toast.error("Proxy must be started first.")
             return
         self.scanning_bacnet_range = True
-        yield rx.toast.info(f"Scanning network: {self.scan_ip_range.network_string}")
         
         try:
             scan_results: BACnetScanResults = await scan_bacnet_ip_range(self.scan_ip_range.network_string)
@@ -2176,7 +2234,7 @@ class BacnetScanState(rx.State):
                 logger.debug(f"we are going to go through {len(points) - 1}")
                 logger.debug(f"sike we only getting 50")
                 # go through each object-list item, skip the first one which is ours, then read property the stuff
-                for obj in points[1:32]:
+                for obj in points[1:81]:
                     logger.debug(f"Processing object: {obj}")
                     
                     object_identifier: str = f"{obj[0]},{obj[1]}"
@@ -2278,6 +2336,7 @@ class BacnetScanState(rx.State):
                     logger.debug(f"Step 7: Creating point model for {point_name}")
                     point = BACnetDevicePointModelView(
                         device_name=point_name,
+                        volttron_point_name=point_name,
                         writable=writable,
                         present_value=present_value,
                         units=units,
@@ -2286,11 +2345,105 @@ class BacnetScanState(rx.State):
                         object_type=object_type
                     )
                     point.safe_point = point.to_dict()
+                    point.set_write_request_target(device.scanned_ip_target, object_identifier)
                     logger.debug(f"Point created: {point}")
                     
                     logger.debug(f"Step 8: Adding point to device {device}")
                     device.points.append(point)
                     logger.debug(f"Point added to device successfully. Device now has {len(device.points)} points.")
+
+
+# # =============================MANUALLY ADDING POINT==============================
+#             logger.debug(f"Manually adding one more point... 2,3000112")
+#             index="3000112"
+#             object_type=self.writable_map[2].type_name
+#             object_identifier="2,{index}"
+#             writable=self.writable_map[2].writable
+
+#             # Getting our point Manually. 
+#             logger.debug(f"Step 1: Getting point name for {object_identifier} at {device.scanned_ip_target}")
+#             point_name_response = await read_bacnet_property(
+#                 BACnetReadPropertyRequest(
+#                     device_address=device.scanned_ip_target,
+#                     object_identifier=object_identifier,
+#                     property_identifier="object-name"
+#                 )
+#             )
+#             logger.debug(f"Point name response received: {point_name_response}")
+#             point_name = point_name_response["result"]["_value"]
+#             logger.debug(f"Point name extracted: {point_name}")
+            
+#             # Getting units
+#             logger.debug(f"Step 2: Getting units for {object_identifier} at {device.scanned_ip_target}")
+#             try:
+#                 units_response = await read_bacnet_property(
+#                     BACnetReadPropertyRequest(
+#                         device_address=device.scanned_ip_target,
+#                         object_identifier=object_identifier,
+#                         property_identifier="units"
+#                     )
+#                 )
+#                 logger.debug(f"Units response received: {units_response}")
+#                 units = units_response["result"]["_value"]
+#                 logger.debug(f"Units extracted: {units}")
+#             except Exception as e:
+#                 logger.error(f"Failed to get units: {e}")
+#                 units = "unknown"
+#                 logger.debug(f"Using default units: {units}")
+            
+#             # Getting present value
+#             logger.debug(f"Step 3: Getting present value for {object_identifier} at {device.scanned_ip_target}")
+#             try:
+#                 present_value_response = await read_bacnet_property(
+#                     BACnetReadPropertyRequest(
+#                         device_address=device.scanned_ip_target,
+#                         object_identifier=object_identifier,
+#                         property_identifier="present-value"
+#                     )
+#                 )
+#                 logger.debug(f"Present value response received: {present_value_response}")
+#                 present_value = present_value_response["result"]["_value"]
+#                 logger.debug(f"Present value extracted: {present_value}")
+#             except Exception as e:
+#                 logger.error(f"Failed to get present value: {e}")
+#                 present_value = "N/A"
+#                 logger.debug(f"Using default present value: {present_value}")
+            
+#             # Getting Notes
+#             logger.debug(f"Step 4: Getting notes for {object_identifier} at {device.scanned_ip_target}")
+#             try:
+#                 notes_value_response = await read_bacnet_property(
+#                     BACnetReadPropertyRequest(
+#                         device_address=device.scanned_ip_target,
+#                         object_identifier=object_identifier,
+#                         property_identifier="notes"
+#                     ),
+#                     timeout=4.0
+#                 )
+#                 logger.debug(f"Notes value response received: {notes_value_response}")
+#                 notes_value = notes_value_response["result"]["_value"]
+#                 logger.debug(f"Notes value extracted: {notes_value}")
+#             except Exception as e:
+#                 logger.error(f"Failed to get notes value: {e}")
+#                 notes_value = ""
+#                 logger.debug(f"Using default notes value: {notes_value}")
+
+
+#             logger.debug(f"Step 5: Creating point model for {point_name}")
+#             point = BACnetDevicePointModelView(
+#                 device_name=point_name,
+#                 volttron_point_name=point_name,
+#                 writable=writable,
+#                 present_value=present_value,
+#                 units=units,
+#                 notes=notes_value,
+#                 index=index,
+#                 object_type=object_type
+#             )
+#             point.safe_point = point.to_dict()
+#             point.set_write_request_target(device.scanned_ip_target, object_identifier)
+#             device.points.append(point)
+# # ======================================================================================
 
             logger.debug(f"this is our scan results: {scan_results}")
             self.discovered_devices = devices
@@ -2328,7 +2481,14 @@ class BacnetScanState(rx.State):
         yield rx.toast.success("Read Property completed.")
     
     @rx.event
-    async def handle_write_property(self):
+    async def handle_write_property(
+        self, 
+        point: BACnetDevicePointModelView, 
+        property_identifier: str, 
+        value: Any, 
+        priority: int, 
+        property_array_index: int | None = None
+    ):
         """Handle the Write Property form submission."""
         if not self.proxy_up:
             yield rx.toast.error("Proxy must be started first.")
@@ -2336,9 +2496,24 @@ class BacnetScanState(rx.State):
             
         yield rx.toast.info(f"Writing to property on {self.write_property.device_address}")
         
-        # TODO: Implement actual BACnet write logic here
-        import asyncio
-        await asyncio.sleep(1)
+        try:
+            logger.debug(f"Writing bacnet property: {property_identifier}, to target: {point.write_request_target}, value: {value}")
+            response = await write_bacnet_property(
+                BACnetWritePropertyRequest(
+                    # **point.write_request_target,
+                    device_address="130.20.24.157",
+                    object_identifier="2,3000112",
+                    # ==============================
+                    property_identifier="present-value",
+                    value=71.0,
+                    priority=priority
+                    # Omit property_array_index for now 
+                )
+            )
+            logger.debug(f"we have written and this is our response: {response}")
+        except:
+            import traceback
+            logger.debug(f"An error occurred writing property {traceback.format_exc()}")
         
         yield rx.toast.success("Write Property completed.")
 
@@ -2374,6 +2549,7 @@ class BacnetScanState(rx.State):
                 async function saveFile() {{
                     try {{
                         const options = {{
+                            suggestedName: 'points',
                             types: [{{
                                 description: 'CSV file',
                                 accept: {{
@@ -2467,7 +2643,8 @@ class BacnetScanState(rx.State):
         """Convert selected_points to CSV string with mapped column names."""
         # Define the CSV columns and their mapping to model fields
         columns = [
-            ("VOLTTRON Point Name", "device_name"),
+            ("Point Name", "device_name"),
+            ("VOLTTRON Point Name", "volttron_point_name"),
             ("Units", "units"),
             ("BACnet Object Type", "object_type"),
             ("Property", "present_value"),

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -16,7 +16,7 @@ from .utils import delete_file
 from loguru import logger
 from typing import Dict, Optional, List
 from .thin_endpoint_wrappers import *
-import string, random, json, csv, yaml, re, io, asyncio
+import string, random, json, csv, yaml, re, io, asyncio, math
 from copy import deepcopy
 from typing import Literal
 
@@ -1575,7 +1575,9 @@ class BacnetScanState(rx.State):
     _is_write_property_valid: bool = False
     _is_read_property_valid: bool = False
     _warn_ping_range: bool = False
-    
+    _point_per_page_limit: int = 20
+    _points_table_page_number: int = 1
+
     # Fields
     proxy_field_value: str = ""
 
@@ -1664,6 +1666,51 @@ class BacnetScanState(rx.State):
 
     # Computed Vars
     @rx.var
+    def total_pages(self) -> int:
+        """Calculate the total number of pages based on points count."""
+        if self.selected_device is None or not self.selected_device.points:
+            return 1
+        
+        total_points = len(self.selected_device.points)
+        return max(1, math.ceil(total_points / self._point_per_page_limit))
+
+    @rx.var
+    def points_table_page_number(self) -> int:
+        """Current page number, clamped to valid range."""
+        # Ensure page number is within bounds
+        if self._points_table_page_number < 1:
+            return 1
+        elif self._points_table_page_number > self.total_pages:
+            return self.total_pages
+        return self._points_table_page_number
+
+    @rx.var
+    def next_page_allowed(self) -> bool:
+        """Whether there's a next page available."""
+        return self.points_table_page_number < self.total_pages
+
+    @rx.var
+    def prev_page_allowed(self) -> bool:
+        """Whether there's a previous page available."""
+        return self.points_table_page_number > 1
+
+    @rx.var
+    def points_to_load(self) -> list[BACnetDevicePointModelView]:
+        """Get the points for the current page."""
+        if self.selected_device is None or not self.selected_device.points:
+            return []
+        
+        page_view_low = (self.points_table_page_number - 1) * self._point_per_page_limit
+        page_view_high = min(page_view_low + self._point_per_page_limit, len(self.selected_device.points))
+        
+        # Safety check to prevent out-of-bounds errors
+        if page_view_low >= len(self.selected_device.points):
+            page_view_low = 0
+            page_view_high = min(self._point_per_page_limit, len(self.selected_device.points))
+        
+        return self.selected_device.points[page_view_low:page_view_high]
+
+    @rx.var
     def warn_ping_range(self) -> bool: 
         self._warn_ping_range = "/" in self.scan_ip_range.network_string
         return self._warn_ping_range
@@ -1702,6 +1749,25 @@ class BacnetScanState(rx.State):
         return []
     
     # Events
+    @rx.event
+    def next_point_page(self):
+        """Go to the next page if available."""
+        if self.next_page_allowed:
+            self._points_table_page_number += 1
+
+    @rx.event
+    def prev_point_page(self):
+        """Go to the previous page if available."""
+        if self.prev_page_allowed:
+            self._points_table_page_number -= 1
+    
+    # May use one day
+    @rx.event
+    def go_to_point_page(self, page_number: int):
+        """Go to a specific page."""
+        if 1 <= page_number <= self.total_pages:
+            self._points_table_page_number = page_number
+
     @rx.event
     def toggle_select_all_points(self, checked: bool):
         self.selected_device.select_all_points = checked
@@ -1897,23 +1963,28 @@ class BacnetScanState(rx.State):
     # Handle Device Point editing
     @rx.event
     def handle_present_value_edit(self, index: int, value: str):
+        index = self.get_absolute_index(index)
         self.selected_device.points[index].present_value = value
 
     @rx.event
     def enable_device_point_present_value_edit(self, index: int):
+        index = self.get_absolute_index(index)
         self.selected_device.points[index].present_value_editing = True
     
     @rx.event
     def disable_device_point_present_value_edit(self, index: int):
+        index = self.get_absolute_index(index)
         self.selected_device.points[index].present_value_editing = False
 
     @rx.event
     def cancel_device_point_present_value_edit(self, index: int):
+        index = self.get_absolute_index(index)
         self.selected_device.points[index].present_value = self.selected_device.points[index].safe_point["present_value"]
         yield BacnetScanState.disable_device_point_present_value_edit(index)
 
     @rx.event
     def save_device_point_present_value_edit(self, index: int):
+        index = self.get_absolute_index(index)
         self.selected_device.points[index].safe_point = self.selected_device.points[index].to_dict()
         yield BacnetScanState.disable_device_point_present_value_edit(index)
         # yield method to write to point
@@ -1993,7 +2064,7 @@ class BacnetScanState(rx.State):
                 logger.debug(f"we are going to go through {len(points) - 1}")
                 logger.debug(f"sike we only getting 50")
                 # go through each object-list item, skip the first one which is ours, then read property the stuff
-                for obj in points[1:21]:
+                for obj in points[1:32]:
                     logger.debug(f"Processing object: {obj}")
                     
                     object_identifier: str = f"{obj[0]},{obj[1]}"
@@ -2153,3 +2224,44 @@ class BacnetScanState(rx.State):
             yield rx.toast.success("Retrieved Host IP")
         except Exception as e:
             logger.debug(f"There was an error getting local ip info {e}")
+
+    def get_absolute_index(self, relative_index: int) -> int:
+        """Convert a relative index (on the current points page) to an absolute index.
+        
+        Args:
+            relative_index: The index of the item on the current page
+            
+        Returns:
+            The absolute index in the full list of points (within self.discovered_device.points)
+        """
+        # Log initial state
+        logger.debug(f"Converting relative_index={relative_index} to absolute index")
+        
+        # Safety check - if no device is selected or no points exist
+        if self.selected_device is None:
+            logger.debug("No device selected, returning index 0")
+            return 0
+        
+        if not self.selected_device.points:
+            logger.debug("Selected device has no points, returning index 0")
+            return 0
+        
+        total_points = len(self.selected_device.points)
+        logger.debug(f"Total points in selected device: {total_points}")
+        
+        # Calculate the start index for the current page
+        page_start_index = (self.points_table_page_number - 1) * self._point_per_page_limit
+        logger.debug(f"Current page: {self.points_table_page_number}, Start index: {page_start_index}")
+        
+        # Calculate the absolute index
+        absolute_index = page_start_index + relative_index
+        logger.debug(f"Calculated absolute_index: {absolute_index}")
+        
+        # Ensure the index doesn't exceed the bounds of the list
+        if absolute_index >= total_points:
+            logger.debug(f"Absolute index {absolute_index} exceeds total points {total_points}, clamping to {total_points-1}")
+            # If out of bounds, return the last valid index
+            return total_points - 1
+        
+        logger.debug(f"Final absolute_index: {absolute_index}")
+        return absolute_index

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -2258,7 +2258,7 @@ class BacnetScanState(rx.State):
             yield rx.toast.success("IP Range scan completed.")
         except:
             import traceback
-            logger.debug(f"An error occured running scan: {traceback.format_exc()}")
+            logger.debug(f"An error occurred running scan: {traceback.format_exc()}")
         
         self.scanning_bacnet_range = False
     

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -313,6 +313,7 @@ class PlatformPageState(rx.State):
     # off of it's instance name, and redirect the user to 
     # platforms/x, maybe we might have to delete the old 
     # routing id
+    session_hydrated: bool = False
     platforms: dict[str, Instance] = {
         # "new": Instance(
         #     host=HostEntryModelView(),
@@ -522,24 +523,26 @@ class PlatformPageState(rx.State):
     # Events
     @rx.event
     async def hydrate_state(self):
-        # Make sure we have a valid 'blank' agent
-        blank_agent = AgentModelView(
-                safe_agent={
-                    "identity" : "",
-                    "source" : "",
-                    "config" : "",
-                    "config_store": {}
-                },
+        if self.session_hydrated == False:
+            # Make sure we have a valid 'blank' agent
+            blank_agent = AgentModelView(
+                    safe_agent={
+                        "identity" : "",
+                        "source" : "",
+                        "config" : "",
+                        "config_store": {}
+                    },
+                )
+            
+            self.list_of_agents = await __agents_off_catalog__()
+            platforms_from_api = await __instances_from_api__()
+            
+            # Ensure we have a blank agent that the user can edit as they so choose
+            self.list_of_agents.append(
+                blank_agent
             )
-        
-        self.list_of_agents = await __agents_off_catalog__()
-        platforms_from_api = await __instances_from_api__()
-        
-        # Ensure we have a blank agent that the user can edit as they so choose
-        self.list_of_agents.append(
-            blank_agent
-        )
-        self.platforms.update(platforms_from_api)
+            self.platforms.update(platforms_from_api)
+            self.session_hydrated = True
 
     @rx.event(background=True)
     async def delete_temp_uid(self, uid_copy: str):
@@ -550,8 +553,8 @@ class PlatformPageState(rx.State):
         logger.debug(f"this is the list of param afters: {list(self.platforms.keys())}")
 
     @rx.event
-    def handle_adding_agent(self, agent: AgentModelView):
-        working_platform = self.platforms[self.current_uid]
+    def handle_adding_agent(self, agent: AgentModelView, uid: str):
+        working_platform = self.platforms[uid]
 
         # Take a copy of the agent we are adding and make sure we dont have an already existing agent of the same identity
         new_agent: AgentModelView = agent.copy()
@@ -807,6 +810,12 @@ class PlatformPageState(rx.State):
         self._host_resolved = self._host_resolvable
         yield
         return
+
+    @rx.event
+    def cement_registry_config(self, working_platform: Instance):
+        logger.debug("Cementing registry config...")
+        self.platforms[working_platform.platform.config.instance_name] = working_platform
+
 
     # NOTE: i would like to offload the uncaught and valid vars into the state vars because it's easier for the UI to read off of 
     # state vars, for faster development, ive kept these here and i'll change it once it's time to refine the code.
@@ -2713,6 +2722,128 @@ class BacnetScanState(rx.State):
     def select_platform_for_registry_config(self, uid: str):
         self.selected_platform_uid = uid if self.selected_platform_uid != uid else ""
 
+    @rx.event
+    async def on_add_to_registry_config(self):
+        yield BacnetScanState.close_dialogs()
+        csv_data = self._convert_selected_points_to_csv()
+        escaped_csv_data = csv_data.replace("'", "\\'")
+        
+        platform_page_state: PlatformPageState = await self.get_state(PlatformPageState)
+        
+        # Check if platform.driver is NOT on the selected platform
+        if "platform.driver" not in list(platform_page_state.platforms[self.selected_platform_uid].platform.agents.keys()):
+            logger.debug("Platform.driver agent not found on platform, adding it...")
+            # Find and add platform driver agent to the platform
+            for agent in platform_page_state.list_of_agents:
+                if agent.identity == "platform.driver":
+                    logger.debug("Found platform.driver agent in list of agents, adding to platform...")
+                    yield PlatformPageState.handle_adding_agent(agent, self.selected_platform_uid)
+                    break
+            else:
+                logger.debug("No platform.driver agent found in the list of agents. Somehow...")
+        else:
+            logger.debug("Platform.driver agent already exists on platform")
+        
+        logger.debug("Adding registry config to platform...")
+        yield BacnetScanState.add_registry_config_to_platform(self.selected_platform_uid, "points.csv", escaped_csv_data)
+        
+    # TODO move all the stuff handiling adding the actual config store entry to its designated state and method
+    @rx.event
+    async def on_add_to_registry_config(self):
+        """Add selected BACnet points to a platform.driver registry configuration."""
+        # Close any open dialogs
+        yield BacnetScanState.close_dialogs()
+        
+        # Convert selected points to CSV format
+        csv_data = self._convert_selected_points_to_csv()
+        escaped_csv_data = csv_data.replace("'", "\\'")
+        
+        platform_uid = self.selected_platform_uid
+        
+        # Step 1: Ensure platform.driver agent exists
+        # yield BacnetScanState.ensure_platform_driver_exists(platform_uid)
+        # we need tto shove the method in here to ensure that it runs one at a time...
+        platform_page_state: PlatformPageState = await self.get_state(PlatformPageState)
+        platform = platform_page_state.platforms.get(platform_uid)
+        if not platform:
+            yield rx.toast.error("Platform not found")
+            return
+        
+        # Find and add platform.driver agent
+        if "platform.driver" not in platform.platform.agents:
+            for agent in platform_page_state.list_of_agents:
+                if agent.identity == "platform.driver":
+                    yield PlatformPageState.handle_adding_agent(agent, platform_uid)
+        # ===============================================================
+
+
+
+
+
+        # Step 2: Add the registry config to the platform.driver agent
+        yield BacnetScanState.add_config_to_platform_driver(
+            platform_uid, 
+            escaped_csv_data
+        )
+
+    @rx.event
+    async def ensure_platform_driver_exists(self, platform_uid: str):
+        """Make sure the platform has a platform.driver agent.
+        
+        Returns:
+            bool: True if platform.driver exists or was successfully added, False otherwise.
+        """
+        platform_page_state: PlatformPageState = await self.get_state(PlatformPageState)
+        platform = platform_page_state.platforms.get(platform_uid)
+        if not platform:
+            return
+        
+        # Check if platform.driver already exists
+        if "platform.driver" in platform.platform.agents:
+            return 
+        
+        # Find and add platform.driver agent
+        for agent in platform_page_state.list_of_agents:
+            if agent.identity == "platform.driver":
+                yield PlatformPageState.handle_adding_agent(agent, platform_uid)
+                # We need to check if the agent was actually added
+                return 
+        
+        # Couldn't find platform.driver in available agents
+        yield rx.toast.error("Could not add platform.driver agent")
+    
+    @rx.event
+    async def add_config_to_platform_driver(
+        self, 
+        platform_uid: str, 
+        csv_value: str
+    ):
+        """Add a config store entry with the CSV value to the platform.driver agent."""
+        platform_page_state: PlatformPageState = await self.get_state(PlatformPageState)
+        platform = platform_page_state.platforms.get(platform_uid)
+        if "platform.driver" not in platform.platform.agents:
+            yield rx.toast.error("Platform or platform.driver agent not found")
+        
+        # Get the platform.driver agent
+        driver_agent = platform.platform.agents.get("platform.driver", None)
+        if driver_agent is None:
+            logger.debug(f"an error occurred, here are the list of agents on the platform: {platform.platform.agents.keys()}")
+            yield rx.toast.error("Platform.driver agent not found on platform")
+            return
+
+        # Create and add the config store entry
+        component_id = generate_unique_uid()
+        config_entry = self._create_config_store_entry("points.csv", csv_value, component_id)
+        driver_agent.config_store.append(config_entry)
+        
+        # Finalize the agent
+        # driver_agent.is_new = False
+        driver_agent.safe_agent = driver_agent.to_dict()
+        
+        # Update the platform state
+        # yield PlatformPageState.cement_registry_config(platform)
+        yield rx.toast.success("BACnet points added to registry")
+
     # Exporting
     @rx.event
     def export_to_csv(self):
@@ -2871,3 +3002,24 @@ class BacnetScanState(rx.State):
         csv_data = output.getvalue()
         output.close()
         return csv_data
+
+    def _create_config_store_entry(self, path: str, csv_value: str, component_id: str) -> ConfigStoreEntryModelView:
+        """Create a new ConfigStoreEntryModelView with the provided values."""
+        new_entry = ConfigStoreEntryModelView(
+            path=path,
+            data_type="CSV",
+            value=csv_value,
+            component_id=component_id,
+            safe_entry={
+                "path": path,
+                "data_type": "CSV",
+                "value": csv_value,
+            }
+        )
+        
+        # Process CSV data
+        usable_csv = csv_string_to_usable_dict(csv_value)
+        new_entry.csv_variants["Custom"] = usable_csv
+        new_entry.safe_entry = new_entry.dict()
+        
+        return new_entry

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -1576,6 +1576,9 @@ class BacnetScanState(rx.State):
     _is_read_property_valid: bool = False
     _warn_ping_range: bool = False
 
+    # Device Points page filter
+    point_table_filters: BACnetPointFilters = BACnetPointFilters()
+
     # For all points pagination
     _point_per_page_limit: int = 20
     _points_table_page_number: int = 1
@@ -1717,6 +1720,20 @@ class BacnetScanState(rx.State):
             page_view_high = min(self._point_per_page_limit, len(self.selected_device.points))
         
         return self.selected_device.points[page_view_low:page_view_high]
+
+    @rx.event
+    def save_point_table_filters(self, form_data: dict):
+        # Update filters based on form data
+        filters = {
+            "units": form_data.get("units") == "on",
+            "present_value": form_data.get("present_value") == "on",
+            "writable": form_data.get("writable") == "on",
+            "index": form_data.get("index") == "on",
+            "notes": form_data.get("notes") == "on",
+        }
+        logger.debug(f"Checkbox filters: {filters}")
+        self.point_table_filters=BACnetPointFilters(**filters)
+        logger.debug(f"this is our table filters now: {self.point_table_filters}")
 
     @rx.var
     def warn_ping_range(self) -> bool: 
@@ -2237,19 +2254,39 @@ class BacnetScanState(rx.State):
                         notes_value = "N/A"
                         logger.debug(f"Using default notes value: {notes_value}")
 
+                    logger.debug(f"Step 5: Getting index for {object_identifier} at {device.scanned_ip_target}")
+                    try:
+                        index_value_response = await read_bacnet_property(
+                            BACnetReadPropertyRequest(
+                                device_address=device.scanned_ip_target,
+                                object_identifier=object_identifier,
+                                property_identifier="index"
+                            ),
+                            timeout=4.0
+                        )
+                        logger.debug(f"Index value response received: {index_value_response}")
+                        index_value = notes_value_response["result"]["_value"]
+                        logger.debug(f"Index value extracted: {index_value}")
+                    except Exception as e:
+                        logger.error(f"Failed to get index value: {e}")
+                        index_value = "N/A"
+                        logger.debug(f"Using default index value: {index_value}")
+
+
                     # Create and add the point to device
-                    logger.debug(f"Step 5: Creating point model for {point_name}")
+                    logger.debug(f"Step 6: Creating point model for {point_name}")
                     point = BACnetDevicePointModelView(
                         device_name=point_name,
                         writable=writable,
                         present_value=present_value,
                         units=units,
-                        notes=notes_value
+                        notes=notes_value,
+                        index=index_value
                     )
                     point.safe_point = point.to_dict()
                     logger.debug(f"Point created: {point}")
                     
-                    logger.debug(f"Step 5: Adding point to device {device}")
+                    logger.debug(f"Step 7: Adding point to device {device}")
                     device.points.append(point)
                     logger.debug(f"Point added to device successfully. Device now has {len(device.points)} points.")
 
@@ -2320,6 +2357,11 @@ class BacnetScanState(rx.State):
             yield rx.toast.success("Retrieved Host IP")
         except Exception as e:
             logger.debug(f"There was an error getting local ip info {e}")
+
+    # Resetting methods:
+    @rx.event
+    def reset_point_table_filters(self):
+        self.point_table_filters = BACnetPointFilters()
 
     def get_absolute_index(self, relative_index: int) -> int:
         """Convert a relative index (on the current points page) to an absolute index.

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -1879,24 +1879,28 @@ class BacnetScanState(rx.State):
         for i, point in enumerate(self.selected_device.points):
             # Check each filter field independently
             # Skip if any filter doesn't match its corresponding field
+            # Only apply filters for columns that are visible (not toggled off)
             
-            # Check volttron_point_name filter
-            if (self.point_table_filter.volttron_point_name and 
+            # Check volttron_point_name filter - only if column is visible
+            if (self.point_column_filter.volttron_point_name and 
+                self.point_table_filter.volttron_point_name and 
                 self.point_table_filter.volttron_point_name.lower() not in str(point.volttron_point_name or "").lower()):
                 continue
             
-            # Check units filter
-            if (self.point_table_filter.units and 
+            # Check units filter - only if column is visible
+            if (self.point_column_filter.units and 
+                self.point_table_filter.units and 
                 self.point_table_filter.units.lower() not in str(point.units or "").lower()):
                 continue
             
-            # Check object_type filter
-            if (self.point_table_filter.object_type and 
+            # Check object_type filter - only if column is visible
+            if (self.point_column_filter.object_type and 
+                self.point_table_filter.object_type and 
                 self.point_table_filter.object_type.lower() not in str(point.object_type or "").lower()):
                 continue
             
-            # Check writable filter - special case as it's a boolean
-            if self.point_table_filter.writable:
+            # Check writable filter - only if column is visible
+            if self.point_column_filter.writable and self.point_table_filter.writable:
                 writable_filter = self.point_table_filter.writable.lower()
                 point_writable_str = str(point.writable).lower()
                 
@@ -1907,18 +1911,21 @@ class BacnetScanState(rx.State):
                 ):
                     continue
             
-            # Check present_value filter
-            if (self.point_table_filter.present_value and 
+            # Check present_value filter - only if column is visible
+            if (self.point_column_filter.present_value and 
+                self.point_table_filter.present_value and 
                 self.point_table_filter.present_value.lower() not in str(point.present_value or "").lower()):
                 continue
             
-            # Check index filter
-            if (self.point_table_filter.index and 
+            # Check index filter - only if column is visible
+            if (self.point_column_filter.index and 
+                self.point_table_filter.index and 
                 self.point_table_filter.index.lower() not in str(point.index or "").lower()):
                 continue
             
-            # Check notes filter
-            if (self.point_table_filter.notes and 
+            # Check notes filter - only if column is visible
+            if (self.point_column_filter.notes and 
+                self.point_table_filter.notes and 
                 self.point_table_filter.notes.lower() not in str(point.notes or "").lower()):
                 continue
             

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -2389,10 +2389,10 @@ class BacnetScanState(rx.State):
                     }} catch (err) {{
                         // Check if this is an abort error (user canceled)
                         if (err.name === 'AbortError') {{
-                            console.log('User canceled the save dialog');
+                            // console.log('User canceled the save dialog');
                             return false;  // User canceled
                         }} else {{
-                            console.error('Save As failed:', err);
+                            // console.error('Save As failed:', err);
                             return false;  // Other error
                         }}
                     }}
@@ -2411,7 +2411,7 @@ class BacnetScanState(rx.State):
                     document.body.removeChild(link);
                     URL.revokeObjectURL(link.href);
                 }} catch (err) {{
-                    console.error('Fallback save method failed:', err);
+                   // console.error('Fallback save method failed:', err);
                 }}
             }}
         """

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -1575,107 +1575,6 @@ class IndexPageState(rx.State):
             self.selected_tool = tool
         logger.debug(f"Selected tool changed to: {self.selected_tool}")
 
-def __create_prefilled_bacnet_device__() -> BACnetDeviceModelView:
-    # Create 5 point model views
-    points = [
-        BACnetDevicePointModelView(
-            device_name="Building1AHU1",
-            volttron_point_name="ZoneTemp1",
-            writable=False,
-            object_type="analogValue",
-            present_value="72.5",
-            units="degF",
-            index=1,
-            notes="Zone temperature sensor",
-            selected=False,
-            present_value_editing=False,
-            volttron_point_name_editing=False,
-            never_writable=True,
-            safe_point={},
-        ),
-        BACnetDevicePointModelView(
-            device_name="Building1AHU1",
-            volttron_point_name="FanStatus",
-            writable=False,
-            object_type="binaryValue",
-            present_value="1",
-            units="no-units",
-            index=2,
-            notes="Fan operational status",
-            selected=False,
-            present_value_editing=False,
-            volttron_point_name_editing=False,
-            safe_point={},
-        ),
-        BACnetDevicePointModelView(
-            device_name="Building1AHU1",
-            volttron_point_name="CoolingValve",
-            writable=True,
-            object_type="analogOutput",
-            present_value="45.0",
-            units="percent",
-            index=3,
-            notes="Cooling valve position",
-            selected=False,
-            present_value_editing=False,
-            volttron_point_name_editing=False,
-            safe_point={},
-        ),
-        BACnetDevicePointModelView(
-            device_name="Building1AHU1",
-            volttron_point_name="HeatingSetpoint",
-            writable=True,
-            object_type="analogValue",
-            present_value="68.0",
-            units="degF",
-            index=4,
-            notes="Heating setpoint",
-            selected=False,
-            present_value_editing=False,
-            volttron_point_name_editing=False,
-            safe_point={},
-        ),
-        BACnetDevicePointModelView(
-            device_name="Building1AHU1",
-            volttron_point_name="OccupancyMode",
-            writable=True,
-            object_type="multiStateValue",
-            present_value="1",
-            units=3,  # Using int for multistate
-            index=5,
-            notes="Occupancy mode (1=Occupied, 2=Unoccupied, 3=Standby)",
-            selected=False,
-            present_value_editing=False,
-            volttron_point_name_editing=False,
-            safe_point={},
-        ),
-    ]
-    
-    # Set write request targets for each point
-    points[0].set_write_request_target("192.168.1.100", "analogValue:1")
-    points[1].set_write_request_target("192.168.1.100", "binaryValue:2")
-    points[2].set_write_request_target("192.168.1.100", "analogOutput:3")
-    points[3].set_write_request_target("192.168.1.100", "analogValue:4")
-    points[4].set_write_request_target("192.168.1.100", "multiStateValue:5")
-
-    for point in points:
-        point.safe_point = point.to_dict()
-
-    # Create the device model view with the points
-    device = BACnetDeviceModelView(
-        deviceIdentifier="100",
-        maxAPDULengthAccepted=1476,
-        segmentationSupported="segmentedBoth",
-        vendorID=15,
-        object_name="Building1AHU1",
-        scanned_ip_target="192.168.1.100",
-        device_instance=100,
-        points=points,
-        select_all_points=False,
-    )
-    
-    return device
-
 class BacnetScanState(rx.State):
     selected_property_tab: Literal["read", "write"] = "read"  # Default to "read" tab
     discovered_devices: list[BACnetDeviceModelView] = []  # Store discovered devices
@@ -1795,13 +1694,6 @@ class BacnetScanState(rx.State):
         53: BACnetObjectType(value=53, type_name="channel", writable=False),
         54: BACnetObjectType(value=54, type_name="lighting-output", writable=False),
     }
-
-
-    @rx.event
-    def set_it(self):
-        self.discovered_devices=[__create_prefilled_bacnet_device__()]
-
-
 
     # important event, actually spins up the tool when the page loads.
     @rx.event

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -1978,14 +1978,14 @@ class BacnetScanState(rx.State):
 
     @rx.event
     def cancel_device_point_present_value_edit(self, index: int):
-        index = self.get_absolute_index(index)
-        self.selected_device.points[index].present_value = self.selected_device.points[index].safe_point["present_value"]
+        absolute_index = self.get_absolute_index(index)
+        self.selected_device.points[index].present_value = self.selected_device.points[absolute_index].safe_point["present_value"]
         yield BacnetScanState.disable_device_point_present_value_edit(index)
 
     @rx.event
     def save_device_point_present_value_edit(self, index: int):
-        index = self.get_absolute_index(index)
-        self.selected_device.points[index].safe_point = self.selected_device.points[index].to_dict()
+        absolute_index = self.get_absolute_index(index)
+        self.selected_device.points[index].safe_point = self.selected_device.points[absolute_index].to_dict()
         yield BacnetScanState.disable_device_point_present_value_edit(index)
         # yield method to write to point
 
@@ -2235,33 +2235,33 @@ class BacnetScanState(rx.State):
             The absolute index in the full list of points (within self.discovered_device.points)
         """
         # Log initial state
-        logger.debug(f"Converting relative_index={relative_index} to absolute index")
+        # logger.debug(f"Converting relative_index={relative_index} to absolute index")
         
         # Safety check - if no device is selected or no points exist
         if self.selected_device is None:
-            logger.debug("No device selected, returning index 0")
+            # logger.debug("No device selected, returning index 0")
             return 0
         
         if not self.selected_device.points:
-            logger.debug("Selected device has no points, returning index 0")
+            # logger.debug("Selected device has no points, returning index 0")
             return 0
         
         total_points = len(self.selected_device.points)
-        logger.debug(f"Total points in selected device: {total_points}")
+        # logger.debug(f"Total points in selected device: {total_points}")
         
         # Calculate the start index for the current page
         page_start_index = (self.points_table_page_number - 1) * self._point_per_page_limit
-        logger.debug(f"Current page: {self.points_table_page_number}, Start index: {page_start_index}")
+        # logger.debug(f"Current page: {self.points_table_page_number}, Start index: {page_start_index}")
         
         # Calculate the absolute index
         absolute_index = page_start_index + relative_index
-        logger.debug(f"Calculated absolute_index: {absolute_index}")
+        # logger.debug(f"Calculated absolute_index: {absolute_index}")
         
         # Ensure the index doesn't exceed the bounds of the list
         if absolute_index >= total_points:
-            logger.debug(f"Absolute index {absolute_index} exceeds total points {total_points}, clamping to {total_points-1}")
+            # logger.debug(f"Absolute index {absolute_index} exceeds total points {total_points}, clamping to {total_points-1}")
             # If out of bounds, return the last valid index
             return total_points - 1
         
-        logger.debug(f"Final absolute_index: {absolute_index}")
+        # logger.debug(f"Final absolute_index: {absolute_index}")
         return absolute_index

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -1821,20 +1821,22 @@ class BacnetScanState(rx.State):
         return self.points_table_page_number > 1
 
     @rx.var
-    def points_to_load(self) -> list[BACnetDevicePointModelView]:
-        """Get the points for the current page."""
-        if self.selected_device is None or not self.selected_device.points:
+    def points_to_load(self) -> list[tuple[int, BACnetDevicePointModelView]]:
+        """Get the points for the current page with their original indices."""
+        filtered_points = self.filtered_points_with_indices
+        
+        if not filtered_points:
             return []
         
         page_view_low = (self.points_table_page_number - 1) * self._point_per_page_limit
-        page_view_high = min(page_view_low + self._point_per_page_limit, len(self.selected_device.points))
+        page_view_high = min(page_view_low + self._point_per_page_limit, len(filtered_points))
         
         # Safety check to prevent out-of-bounds errors
-        if page_view_low >= len(self.selected_device.points):
+        if page_view_low >= len(filtered_points):
             page_view_low = 0
-            page_view_high = min(self._point_per_page_limit, len(self.selected_device.points))
+            page_view_high = min(self._point_per_page_limit, len(filtered_points))
         
-        return self.selected_device.points[page_view_low:page_view_high]
+        return filtered_points[page_view_low:page_view_high]
 
     @rx.event
     def save_point_table_filters(self, form_data: dict):
@@ -1939,6 +1941,15 @@ class BacnetScanState(rx.State):
         """Whether there's a previous page available for selected points."""
         return self.selected_points_page_number > 1
 
+    @rx.var
+    def filtered_points_with_indices(self) -> list[tuple[int, BACnetDevicePointModelView]]:
+        """Return filtered points with their original indices."""
+        return self.apply_point_table_filters(self.point_table_filter)
+
+    @rx.var
+    def filtered_points(self) -> list[BACnetDevicePointModelView]:
+        """Return just the filtered points."""
+        return [point for _, point in self.filtered_points_with_indices]
 
     # Events
     # For points pagination
@@ -2731,46 +2742,67 @@ class BacnetScanState(rx.State):
         self.point_column_filter = BACnetPointColumnFilters()
 
     def get_absolute_index(self, relative_index: int) -> int:
-        """Convert a relative index (on the current points page) to an absolute index.
+        """
+        Convert a relative index (page position) to an absolute index in the original points list.
         
         Args:
-            relative_index: The index of the item on the current page
+            relative_index: The index within the current page view
             
         Returns:
-            The absolute index in the full list of points (within self.discovered_device.points)
+            The absolute index in the original points list
         """
-        # Log initial state
-        # logger.debug(f"Converting relative_index={relative_index} to absolute index")
+        points_to_load = self.points_to_load
         
-        # Safety check - if no device is selected or no points exist
-        if self.selected_device is None:
-            # logger.debug("No device selected, returning index 0")
-            return 0
+        if not points_to_load or relative_index >= len(points_to_load):
+            return -1  # Invalid index
         
-        if not self.selected_device.points:
-            # logger.debug("Selected device has no points, returning index 0")
-            return 0
-        
-        total_points = len(self.selected_device.points)
-        # logger.debug(f"Total points in selected device: {total_points}")
-        
-        # Calculate the start index for the current page
-        page_start_index = (self.points_table_page_number - 1) * self._point_per_page_limit
-        # logger.debug(f"Current page: {self.points_table_page_number}, Start index: {page_start_index}")
-        
-        # Calculate the absolute index
-        absolute_index = page_start_index + relative_index
-        # logger.debug(f"Calculated absolute_index: {absolute_index}")
-        
-        # Ensure the index doesn't exceed the bounds of the list
-        if absolute_index >= total_points:
-            # logger.debug(f"Absolute index {absolute_index} exceeds total points {total_points}, clamping to {total_points-1}")
-            # If out of bounds, return the last valid index
-            return total_points - 1
-        
-        # logger.debug(f"Final absolute_index: {absolute_index}")
-        return absolute_index
+        # Get the original index stored in the tuple
+        original_index, _ = points_to_load[relative_index]
+        return original_index
     
+    def apply_point_table_filters(self, filters: BACnetPointTableFilter) -> list[tuple[int, BACnetDevicePointModelView]]:
+        """
+        Apply filters to the data points and return filtered results with their original indices.
+        
+        Args:
+            filters: BACnetPointTableFilter instance containing filter criteria
+            
+        Returns:
+            List of tuples (original_index, point)
+        """
+        if self.selected_device is None:
+            return []
+        
+        # Start with all points and their original indices
+        points_with_indices = list(enumerate(self.selected_device.points))
+        
+        # Define a helper function to apply a single filter
+        def apply_filter(points_with_indices, filter_value, column_enabled, attr_name):
+            if filter_value == "" or not column_enabled:
+                return points_with_indices
+            
+            return [
+                (idx, point) for idx, point in points_with_indices 
+                if filter_value.lower() in str(getattr(point, attr_name, "")).lower()
+            ]
+        
+        # Apply each filter sequentially
+        filter_specs = [
+            (filters.volttron_point_name, self.point_column_filter.volttron_point_name, "volttron_point_name"),
+            (filters.units, self.point_column_filter.units, "units"),
+            (filters.object_type, self.point_column_filter.object_type, "object_type"),
+            (filters.writable, self.point_column_filter.writable, "writable"),
+            (filters.present_value, self.point_column_filter.present_value, "present_value"),
+            (filters.index, self.point_column_filter.index, "index"),
+            (filters.notes, self.point_column_filter.notes, "notes")
+        ]
+        
+        # Apply each filter in sequence
+        for filter_value, column_enabled, attr_name in filter_specs:
+            points_with_indices = apply_filter(points_with_indices, filter_value, column_enabled, attr_name)
+        
+        return points_with_indices
+
     def _convert_selected_points_to_csv(self) -> str:
         """Convert selected_points to CSV string with mapped column names."""
         # Define the CSV columns and their mapping to model fields

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -319,6 +319,7 @@ class PlatformPageState(rx.State):
         #     platform=PlatformModelView()
         # )
     }
+    _working_platform: Instance = Instance(host=HostEntryModelView(), platform=PlatformModelView())
     list_of_agents: list[AgentModelView] = []
 
     _host_resolvable: bool = True
@@ -335,6 +336,16 @@ class PlatformPageState(rx.State):
     @rx.var(cache=True)
     def current_uid(self) -> str:
         return self.router.page.params.get("uid", "")
+
+    @rx.var
+    def working_platform(self) -> Instance:
+        self._working_platform = self.platforms.get(self.current_uid, Instance(host=HostEntryModelView(), platform=PlatformModelView()))
+        return self._working_platform
+
+    @rx.var
+    def raka(self) -> str:
+        return f"{len(self.working_platform.platform.agents)}"
+
 
     @rx.var(cache=True)
     def in_file_platforms(self) -> list[Instance]:

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -1575,8 +1575,14 @@ class BacnetScanState(rx.State):
     _is_write_property_valid: bool = False
     _is_read_property_valid: bool = False
     _warn_ping_range: bool = False
+
+    # For all points pagination
     _point_per_page_limit: int = 20
     _points_table_page_number: int = 1
+    
+    # For selected points pagination
+    _selected_points_per_page_limit: int = 15
+    _selected_points_page_number: int = 1
 
     # Fields
     proxy_field_value: str = ""
@@ -1665,6 +1671,8 @@ class BacnetScanState(rx.State):
 
 
     # Computed Vars
+
+    # For point pagination
     @rx.var
     def total_pages(self) -> int:
         """Calculate the total number of pages based on points count."""
@@ -1742,13 +1750,66 @@ class BacnetScanState(rx.State):
         self._is_write_property_valid = True
         return self._is_write_property_valid
 
+    # For selected points pagination
     @rx.var
     def selected_points(self) -> list[BACnetDevicePointModelView]:
         if self.selected_device is not None:
-            return [point for point in self.selected_device.points]
+            return [point for point in self.selected_device.points if point.selected]
         return []
     
+    @rx.var
+    def selected_points_total(self) -> int:
+        """Get the total count of selected points."""
+        return len(self.selected_points)
+
+    @rx.var
+    def selected_points_total_pages(self) -> int:
+        """Calculate the total number of pages for selected points."""
+        if not self.selected_points:
+            return 1
+        return max(1, math.ceil(self.selected_points_total / self._selected_points_per_page_limit))
+
+    @rx.var
+    def selected_points_page_number(self) -> int:
+        """Get the current page number for selected points, with bounds checking."""
+        # Ensure page number is within bounds
+        if self._selected_points_page_number < 1:
+            return 1
+        elif self._selected_points_page_number > self.selected_points_total_pages:
+            return self.selected_points_total_pages
+        return self._selected_points_page_number
+
+    @rx.var
+    def paginated_selected_points(self) -> list[BACnetDevicePointModelView]:
+        """Get the selected points for the current page only."""
+        all_selected = self.selected_points
+        
+        if not all_selected:
+            return []
+        
+        start_idx = (self.selected_points_page_number - 1) * self._selected_points_per_page_limit
+        end_idx = min(start_idx + self._selected_points_per_page_limit, len(all_selected))
+        
+        # Safety check
+        if start_idx >= len(all_selected):
+            start_idx = 0
+            end_idx = min(self._selected_points_per_page_limit, len(all_selected))
+        
+        return all_selected[start_idx:end_idx]
+
+    @rx.var
+    def selected_points_has_next_page(self) -> bool:
+        """Whether there's a next page available for selected points."""
+        return self.selected_points_page_number < self.selected_points_total_pages
+
+    @rx.var
+    def selected_points_has_prev_page(self) -> bool:
+        """Whether there's a previous page available for selected points."""
+        return self.selected_points_page_number > 1
+
+
     # Events
+    # For points pagination
     @rx.event
     def next_point_page(self):
         """Go to the next page if available."""
@@ -1768,16 +1829,47 @@ class BacnetScanState(rx.State):
         if 1 <= page_number <= self.total_pages:
             self._points_table_page_number = page_number
 
+    # For selected points pagination
+    @rx.event
+    def selected_points_next_page(self):
+        """Go to the next page of selected points if available."""
+        if self.selected_points_has_next_page:
+            self._selected_points_page_number += 1
+
+    @rx.event
+    def selected_points_prev_page(self):
+        """Go to the previous page of selected points if available."""
+        if self.selected_points_has_prev_page:
+            self._selected_points_page_number -= 1
+            
+    @rx.event
+    def selected_points_go_to_page(self, page: int):
+        """Go to a specific page of selected points."""
+        if 1 <= page <= self.selected_points_total_pages:
+            self._selected_points_page_number = page
+
+    @rx.event
+    def on_selected_points_dialog_close(self):
+        self._selected_points_page_number = 1
+
+
     @rx.event
     def toggle_select_all_points(self, checked: bool):
         self.selected_device.select_all_points = checked
         for point in self.selected_device.points:
             point.selected=checked
 
+        # Reset to first page when selections change
+        self._selected_points_page_number = 1
+
     @rx.event
     def handle_device_check(self, device_index: int, checked: bool):
+        device_index = self.get_absolute_index(device_index)
         self.selected_device.select_all_points = False
         self.selected_device.points[device_index].selected = checked
+        
+        # Reset to first page when selections change
+        self._selected_points_page_number = 1
 
     @rx.event
     def handle_proxy_field_edit(self, value: str):

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -1561,6 +1561,108 @@ class IndexPageState(rx.State):
 
 
 
+def __create_prefilled_bacnet_device__() -> BACnetDeviceModelView:
+    # Create 5 point model views
+    points = [
+        BACnetDevicePointModelView(
+            device_name="Building1AHU1",
+            volttron_point_name="ZoneTemp1",
+            writable=True,
+            object_type="analogValue",
+            present_value="72.5",
+            units="degF",
+            index=1,
+            notes="Zone temperature sensor",
+            selected=False,
+            present_value_editing=False,
+            volttron_point_name_editing=False,
+            safe_point={},
+        ),
+        BACnetDevicePointModelView(
+            device_name="Building1AHU1",
+            volttron_point_name="FanStatus",
+            writable=False,
+            object_type="binaryValue",
+            present_value="1",
+            units="no-units",
+            index=2,
+            notes="Fan operational status",
+            selected=False,
+            present_value_editing=False,
+            volttron_point_name_editing=False,
+            safe_point={},
+        ),
+        BACnetDevicePointModelView(
+            device_name="Building1AHU1",
+            volttron_point_name="CoolingValve",
+            writable=True,
+            object_type="analogOutput",
+            present_value="45.0",
+            units="percent",
+            index=3,
+            notes="Cooling valve position",
+            selected=False,
+            present_value_editing=False,
+            volttron_point_name_editing=False,
+            safe_point={},
+        ),
+        BACnetDevicePointModelView(
+            device_name="Building1AHU1",
+            volttron_point_name="HeatingSetpoint",
+            writable=True,
+            object_type="analogValue",
+            present_value="68.0",
+            units="degF",
+            index=4,
+            notes="Heating setpoint",
+            selected=False,
+            present_value_editing=False,
+            volttron_point_name_editing=False,
+            safe_point={},
+        ),
+        BACnetDevicePointModelView(
+            device_name="Building1AHU1",
+            volttron_point_name="OccupancyMode",
+            writable=True,
+            object_type="multiStateValue",
+            present_value="1",
+            units=3,  # Using int for multistate
+            index=5,
+            notes="Occupancy mode (1=Occupied, 2=Unoccupied, 3=Standby)",
+            selected=False,
+            present_value_editing=False,
+            volttron_point_name_editing=False,
+            safe_point={},
+        ),
+    ]
+    
+    # Set write request targets for each point
+    points[0].set_write_request_target("192.168.1.100", "analogValue:1")
+    points[1].set_write_request_target("192.168.1.100", "binaryValue:2")
+    points[2].set_write_request_target("192.168.1.100", "analogOutput:3")
+    points[3].set_write_request_target("192.168.1.100", "analogValue:4")
+    points[4].set_write_request_target("192.168.1.100", "multiStateValue:5")
+
+    for point in points:
+        point.safe_point = point.to_dict()
+
+    # Create the device model view with the points
+    device = BACnetDeviceModelView(
+        pduSource="192.168.1.100",
+        deviceIdentifier="100",
+        maxAPDULengthAccepted=1476,
+        segmentationSupported="segmentedBoth",
+        vendorID=15,
+        object_name="Building1AHU1",
+        scanned_ip_target="192.168.1.100",
+        device_instance=100,
+        points=points,
+        select_all_points=False,
+    )
+    
+    return device
+
+
 class BacnetScanState(rx.State):
     selected_property_tab: Literal["read", "write"] = "read"  # Default to "read" tab
     discovered_devices: list[BACnetDeviceModelView] = []  # Store discovered devices
@@ -1576,8 +1678,9 @@ class BacnetScanState(rx.State):
     _is_read_property_valid: bool = False
     _warn_ping_range: bool = False
 
-    # Device Points page filter
-    point_table_filters: BACnetPointFilters = BACnetPointFilters()
+    # Device Points page filters
+    point_table_filter: BACnetPointTableFilter = BACnetPointTableFilter()
+    point_column_filter: BACnetPointColumnFilters = BACnetPointColumnFilters()
 
     # For all points pagination
     _point_per_page_limit: int = 20
@@ -1608,41 +1711,42 @@ class BacnetScanState(rx.State):
 
     # For bacnet point stuff
     writable_map: Dict[int, BACnetObjectType] = {
+        # INPUTS NEVER, some maybe
         0: BACnetObjectType(value=0, type_name="analog-input", writable=False),
         1: BACnetObjectType(value=1, type_name="analog-output", writable=True),
-        2: BACnetObjectType(value=2, type_name="analog-value", writable=False),
+        2: BACnetObjectType(value=2, type_name="analog-value", writable=True),
         3: BACnetObjectType(value=3, type_name="binary-input", writable=False),
         4: BACnetObjectType(value=4, type_name="binary-output", writable=True),
-        5: BACnetObjectType(value=5, type_name="binary-value", writable=False),
+        5: BACnetObjectType(value=5, type_name="binary-value", writable=True),
         6: BACnetObjectType(value=6, type_name="calendar", writable=True),
-        7: BACnetObjectType(value=7, type_name="command", writable=True),
-        8: BACnetObjectType(value=8, type_name="device", writable=False),
-        9: BACnetObjectType(value=9, type_name="event-enrollment", writable=True),
-        10: BACnetObjectType(value=10, type_name="file", writable=True),
-        11: BACnetObjectType(value=11, type_name="group", writable=True),
-        12: BACnetObjectType(value=12, type_name="loop", writable=True),
+        7: BACnetObjectType(value=7, type_name="command", writable=False),
+        8: BACnetObjectType(value=8, type_name="device", writable=False), # NEVER
+        9: BACnetObjectType(value=9, type_name="event-enrollment", writable=False),
+        10: BACnetObjectType(value=10, type_name="file", writable=False),
+        11: BACnetObjectType(value=11, type_name="group", writable=False),
+        12: BACnetObjectType(value=12, type_name="loop", writable=False),
         13: BACnetObjectType(value=13, type_name="multi-state-input", writable=False),
         14: BACnetObjectType(value=14, type_name="multi-state-output", writable=True),
         15: BACnetObjectType(value=15, type_name="notification-class", writable=True),
         16: BACnetObjectType(value=16, type_name="program", writable=True),
         17: BACnetObjectType(value=17, type_name="schedule", writable=True),
         18: BACnetObjectType(value=18, type_name="averaging", writable=False),
-        19: BACnetObjectType(value=19, type_name="multi-state-value", writable=False),
+        19: BACnetObjectType(value=19, type_name="multi-state-value", writable=True),
         20: BACnetObjectType(value=20, type_name="trend-log", writable=False),
         21: BACnetObjectType(value=21, type_name="life-safety-point", writable=False),
         22: BACnetObjectType(value=22, type_name="life-safety-zone", writable=False),
         23: BACnetObjectType(value=23, type_name="accumulator", writable=False),
         24: BACnetObjectType(value=24, type_name="pulse-converter", writable=False),
         25: BACnetObjectType(value=25, type_name="event-log", writable=False),
-        26: BACnetObjectType(value=26, type_name="global-group", writable=True),
+        26: BACnetObjectType(value=26, type_name="global-group", writable=False),
         27: BACnetObjectType(value=27, type_name="trend-log-multiple", writable=False),
-        28: BACnetObjectType(value=28, type_name="load-control", writable=True),
+        28: BACnetObjectType(value=28, type_name="load-control", writable=False),
         29: BACnetObjectType(value=29, type_name="structured-view", writable=False),
-        30: BACnetObjectType(value=30, type_name="access-door", writable=True),
+        30: BACnetObjectType(value=30, type_name="access-door", writable=False),
         31: BACnetObjectType(value=31, type_name="unassigned", writable=False),
         32: BACnetObjectType(value=32, type_name="access-credential", writable=False),
         33: BACnetObjectType(value=33, type_name="access-point", writable=False),
-        34: BACnetObjectType(value=34, type_name="access-rights", writable=True),
+        34: BACnetObjectType(value=34, type_name="access-rights", writable=False),
         35: BACnetObjectType(value=35, type_name="access-user", writable=False),
         36: BACnetObjectType(value=36, type_name="access-zone", writable=False),
         37: BACnetObjectType(value=37, type_name="credentional-data-input", writable=False),
@@ -1659,11 +1763,18 @@ class BacnetScanState(rx.State):
         48: BACnetObjectType(value=48, type_name="positive-integer-value", writable=False),
         49: BACnetObjectType(value=49, type_name="time-pattern-value", writable=False),
         50: BACnetObjectType(value=50, type_name="time-value", writable=False),
-        51: BACnetObjectType(value=51, type_name="notification-forwarder", writable=True),
-        52: BACnetObjectType(value=52, type_name="alert-enrollment", writable=True),
-        53: BACnetObjectType(value=53, type_name="channel", writable=True),
-        54: BACnetObjectType(value=54, type_name="lighting-output", writable=True),
+        51: BACnetObjectType(value=51, type_name="notification-forwarder", writable=False),
+        52: BACnetObjectType(value=52, type_name="alert-enrollment", writable=False),
+        53: BACnetObjectType(value=53, type_name="channel", writable=False),
+        54: BACnetObjectType(value=54, type_name="lighting-output", writable=False),
     }
+
+
+    @rx.event
+    def set_it(self):
+        self.discovered_devices=[__create_prefilled_bacnet_device__()]
+
+
 
     # important event, actually spins up the tool when the page loads.
     @rx.event
@@ -1737,7 +1848,7 @@ class BacnetScanState(rx.State):
             "index": form_data.get("index") == "on",
             "notes": form_data.get("notes") == "on",
         }
-        self.point_table_filters=BACnetPointFilters(**filters)
+        self.point_column_filter=BACnetPointColumnFilters(**filters)
 
     @rx.var
     def warn_ping_range(self) -> bool: 
@@ -1889,6 +2000,25 @@ class BacnetScanState(rx.State):
     def on_selected_points_dialog_close(self):
         self._selected_points_page_number = 1
 
+    @rx.event
+    def filter_form_submit(self, form_data: dict):
+        self.point_table_filter = BACnetPointTableFilter(
+            volttron_point_name=form_data.get("volttron_point_name", ""),
+            units=form_data.get("units", ""),
+            object_type=form_data.get("object_type", ""),
+            writable=form_data.get("writable", "").strip(),
+            present_value=form_data.get("present_value", ""),
+            index=form_data.get("index", ""),
+            notes=form_data.get("notes", "")
+        )
+
+    @rx.event
+    def clear_point_filter(self, field: str):
+        change: dict[str, str] = self.point_table_filter.dict()
+        change[field] = ""  # Clear the specified field
+        self.point_table_filter = BACnetPointTableFilter(
+            **change
+        )
 
     @rx.event
     def toggle_select_all_points(self, checked: bool):
@@ -2598,7 +2728,7 @@ class BacnetScanState(rx.State):
     # Resetting methods
     @rx.event
     def reset_point_table_filters(self):
-        self.point_table_filters = BACnetPointFilters()
+        self.point_column_filter = BACnetPointColumnFilters()
 
     def get_absolute_index(self, relative_index: int) -> int:
         """Convert a relative index (on the current points page) to an absolute index.

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -19,6 +19,7 @@ from .thin_endpoint_wrappers import *
 import string, random, json, csv, yaml, re, io, asyncio, math
 from copy import deepcopy
 from typing import Literal
+from bacnet_scan_tool.models import ObjectListNamesResponse
 
 class AppState(rx.State):
     """The app state."""
@@ -342,11 +343,6 @@ class PlatformPageState(rx.State):
     def working_platform(self) -> Instance:
         self._working_platform = self.platforms.get(self.current_uid, Instance(host=HostEntryModelView(), platform=PlatformModelView()))
         return self._working_platform
-
-    @rx.var
-    def raka(self) -> str:
-        return f"{len(self.working_platform.platform.agents)}"
-
 
     @rx.var(cache=True)
     def in_file_platforms(self) -> list[Instance]:
@@ -1667,7 +1663,6 @@ def __create_prefilled_bacnet_device__() -> BACnetDeviceModelView:
 
     # Create the device model view with the points
     device = BACnetDeviceModelView(
-        pduSource="192.168.1.100",
         deviceIdentifier="100",
         maxAPDULengthAccepted=1476,
         segmentationSupported="segmentedBoth",
@@ -1711,6 +1706,7 @@ class BacnetScanState(rx.State):
     # Dialog States
     dialog_registry_open: bool = False
     dialog_select_platform_open: bool = False
+    dialog_confirm_add_platform_agent: bool = False
     selected_platform_uid: str = ""
 
     # Fields
@@ -1727,6 +1723,11 @@ class BacnetScanState(rx.State):
     # UI driven models
     local_ip_info: LocalIPModel = LocalIPModel()
     windows_host_ip_info: WindowsHostIPModel = WindowsHostIPModel()
+    all_device_scan_point_status: list[BACnetDevicePointScanStatus] = []
+
+
+    _platform_has_platform_driver: bool = True
+
 
     # For bacnet point stuff
     NEVER_WRITABLE: list[int] = [
@@ -1815,16 +1816,23 @@ class BacnetScanState(rx.State):
 
 
     # Computed Vars
+    @rx.var
+    def platform_has_platform_driver(self) -> bool:
+        if self.selected_platform_uid == "":
+            return True
+        return self._platform_has_platform_driver
+        
 
     # For point pagination
     @rx.var
     def total_pages(self) -> int:
-        """Calculate the total number of pages based on points count."""
-        if self.selected_device is None or not self.selected_device.points:
+        """Calculate the total number of pages based on filtered points count."""
+        if self.selected_device is None or not self.filtered_points_with_indices:
             return 1
         
-        total_points = len(self.selected_device.points)
-        return max(1, math.ceil(total_points / self._point_per_page_limit))
+        # Use the length of filtered points
+        total_filtered_points = len(self.filtered_points_with_indices)
+        return max(1, math.ceil(total_filtered_points / self._point_per_page_limit))
 
     @rx.var
     def points_table_page_number(self) -> int:
@@ -1877,6 +1885,7 @@ class BacnetScanState(rx.State):
             "notes": form_data.get("notes") == "on",
         }
         self.point_column_filter=BACnetPointColumnFilters(**filters)
+        self._points_table_page_number = 1  # Reset to first page when filters change
 
     @rx.var
     def warn_ping_range(self) -> bool: 
@@ -1969,8 +1978,62 @@ class BacnetScanState(rx.State):
 
     @rx.var
     def filtered_points_with_indices(self) -> list[tuple[int, BACnetDevicePointModelView]]:
-        """Return filtered points with their original indices."""
-        return self.apply_point_table_filters(self.point_table_filter)
+        """Get all points that match the current filter, with their original indices."""
+        if self.selected_device is None or not self.selected_device.points:
+            return []
+        
+        # Apply filters to the points
+        filtered_points = []
+        for i, point in enumerate(self.selected_device.points):
+            # Check each filter field independently
+            # Skip if any filter doesn't match its corresponding field
+            
+            # Check volttron_point_name filter
+            if (self.point_table_filter.volttron_point_name and 
+                self.point_table_filter.volttron_point_name.lower() not in str(point.volttron_point_name or "").lower()):
+                continue
+            
+            # Check units filter
+            if (self.point_table_filter.units and 
+                self.point_table_filter.units.lower() not in str(point.units or "").lower()):
+                continue
+            
+            # Check object_type filter
+            if (self.point_table_filter.object_type and 
+                self.point_table_filter.object_type.lower() not in str(point.object_type or "").lower()):
+                continue
+            
+            # Check writable filter - special case as it's a boolean
+            if self.point_table_filter.writable:
+                writable_filter = self.point_table_filter.writable.lower()
+                point_writable_str = str(point.writable).lower()
+                
+                # Filter for "true"/"false" or partial matches like "t" for true
+                if writable_filter not in point_writable_str and (
+                    (writable_filter.startswith("t") and not point.writable) or
+                    (writable_filter.startswith("f") and point.writable)
+                ):
+                    continue
+            
+            # Check present_value filter
+            if (self.point_table_filter.present_value and 
+                self.point_table_filter.present_value.lower() not in str(point.present_value or "").lower()):
+                continue
+            
+            # Check index filter
+            if (self.point_table_filter.index and 
+                self.point_table_filter.index.lower() not in str(point.index or "").lower()):
+                continue
+            
+            # Check notes filter
+            if (self.point_table_filter.notes and 
+                self.point_table_filter.notes.lower() not in str(point.notes or "").lower()):
+                continue
+            
+            # If we get here, the point passed all filters
+            filtered_points.append((i, point))
+        
+        return filtered_points
 
     @rx.var
     def filtered_points(self) -> list[BACnetDevicePointModelView]:
@@ -1978,6 +2041,222 @@ class BacnetScanState(rx.State):
         return [point for _, point in self.filtered_points_with_indices]
 
     # Events
+    # Background tasks
+    @rx.event(background=True)
+    async def scan_for_points(self, device: BACnetDeviceModelView, device_index: int, total_points_amount: int):
+        """Background task to scan for points from an object list."""
+        logger.debug(f"Starting background point scan for device {device.scanned_ip_target}")
+        
+        # Create status object and add it to the list
+        status_id = len(self.all_device_scan_point_status)
+        device_name = device.object_name
+        
+        # Get device index
+        device_object_index: list[str] = device.deviceIdentifier.split(",")
+        device_identifier: str = device_object_index[1]
+
+        status = BACnetDevicePointScanStatus(
+            message=f"Scanning {total_points_amount} points on device: {device_name}...",
+            device_name=device_name,
+            percent_finished=0,
+            object_name=device.object_name  # Using the device's object_name
+        )
+        
+        async with self:
+            self.all_device_scan_point_status.append(status)
+        yield BacnetScanState.update_ui()
+        
+        try:
+            # Calculate total pages needed
+            total_pages = (total_points_amount + self._point_per_page_limit - 1) // self._point_per_page_limit
+            logger.debug(f"Scanning {total_points_amount} points across {total_pages} pages")
+            
+            # Clear existing points if needed
+            device.points = []
+            
+            # Update status
+            async with self:
+                self.all_device_scan_point_status[status_id].message = f"Preparing to scan {total_points_amount} points..."
+            yield BacnetScanState.update_ui()
+            
+            # Iterate through all pages
+            points_processed = 0
+            for current_page in range(1, total_pages + 1):
+                logger.debug(f"Requesting page {current_page} of {total_pages}")
+                
+                # Update status - indicate how many points we've processed and how many more to go
+                points_so_far = min(points_processed, total_points_amount)
+                
+                async with self:
+                    self.all_device_scan_point_status[status_id].message = f"Reading points {points_so_far+1}-{min(points_so_far+self._point_per_page_limit, total_points_amount)} of {total_points_amount}..."
+                    self.all_device_scan_point_status[status_id].percent_finished = int(points_so_far / total_points_amount * 100)
+                yield BacnetScanState.update_ui()
+                
+                res: ObjectListNamesResponse = await read_bacnet_object_list_names(
+                    BACnetReadObjectListRequest(
+                        device_address=device.scanned_ip_target,
+                        device_object_identifier=device.deviceIdentifier,
+                        page_size=self._point_per_page_limit,
+                        page=current_page
+                    )
+                )
+                
+                if res.status != "done":
+                    logger.error(f"Error getting points {points_so_far+1}-{min(points_so_far+self._point_per_page_limit, total_points_amount)}: {res.error}")
+                    async with self:
+                        self.all_device_scan_point_status[status_id].message = f"Error retrieving points {points_so_far+1}-{min(points_so_far+self._point_per_page_limit, total_points_amount)}: {res.error}"
+                    yield BacnetScanState.update_ui()
+                    points_processed += self._point_per_page_limit  # Move to next page even if there was an error
+                    continue
+                    
+                # Update status - processing points
+                points_in_page = len(res.results)
+                async with self:
+                    self.all_device_scan_point_status[status_id].message = f"Processing {points_in_page} points ({points_so_far+1}-{points_so_far+points_in_page} of {total_points_amount})..."
+                yield BacnetScanState.update_ui()
+                    
+                # Process the results for this page
+                for i, (object_identifier, properties) in enumerate(res.results.items()):
+                    try:
+                        # Occasionally update processing status
+                        if i % 5 == 0:  # Update every 5 points
+                            async with self:
+                                self.all_device_scan_point_status[status_id].message = f"Processing point {points_so_far+i+1} of {total_points_amount}..."
+                                self.all_device_scan_point_status[status_id].percent_finished = int(
+                                    (points_so_far + i) / total_points_amount * 100
+                                )
+                            yield BacnetScanState.update_ui()
+                        
+                        # Parse the object identifier to get type and instance
+                        obj_parts = object_identifier.split(",")
+                        if len(obj_parts) != 2:
+                            logger.warning(f"Invalid object identifier format: {object_identifier}")
+                            continue
+                            
+                        object_type = obj_parts[0]
+                        index_value = obj_parts[1]
+                        
+                        # Make sure we are skipping the the "host" device within the points
+                        if f"{index_value}" == f"{device_identifier}":
+                            logger.info("Skipping `host` device of the points within the object-list")
+                            continue
+
+                        # Extract properties
+                        point_name = properties.object_name or f"Unknown-{object_identifier}"
+                        units = properties.units
+                        present_value = properties.present_value
+                        
+                        # Determine if point is writable and never writable
+                        writable: bool = False
+                        never_writable: bool = False
+                        for k, v in self.writable_map.items():
+                            if v.type_name == object_type:
+                                writable=v.writable
+                                if k in self.NEVER_WRITABLE:
+                                    never_writable = True
+                                break
+                        else:
+                            logger.warning(f"Object type {object_type} not found in writable map, using default, writable=False, never_writable=False")
+                        
+                        # Lets try to read property the notes
+                        try:
+                            type_int = ""
+                            for k, v in self.writable_map.items():
+                                if v.type_name == object_type:
+                                    type_int = v.type_name
+                                    break
+                            else:
+                                logger.warning(f"Object type {object_type} not found in writable map, using default")
+                                type_int = "unknown"
+                                
+                            res_notes = await read_bacnet_property(
+                                BACnetReadPropertyRequest(
+                                    device_address=device.scanned_ip_target,
+                                    object_identifier=f"{type_int},{index_value}",
+                                    property_identifier="notes"
+                                ),
+                                timeout=4.0
+                            )
+                            data = res_notes.json()
+                            
+                            # Extract notes value from response if available
+                            notes_value = ""  # Default value
+                            
+                            logger.debug(f"Response for notes property: {data}")
+                            notes_value=data["result"]["_value"]                            
+                            logger.debug(f"Retrieved notes for {object_identifier}: {notes_value}")
+                            
+                        except Exception as e:
+                            # If notes property read fails, use default value of ""
+                            notes_value = ""
+                            logger.debug(f"Failed to read notes property for {object_identifier}: {e}")
+                        except Exception as e:
+                            import traceback
+                            logger.debug(f"an error occurred: {traceback.format_exc()}")
+                            
+                        # Create point model
+                        point = BACnetDevicePointModelView(
+                            device_name=point_name,
+                            volttron_point_name=point_name,
+                            writable=writable,
+                            present_value=present_value if present_value is not None else "",
+                            units=units if units is not None else "",
+                            notes=notes_value,
+                            index=index_value,
+                            object_type=object_type,
+                            never_writable=never_writable
+                        )
+                        point.safe_point = point.to_dict()
+                        point.set_write_request_target(device.scanned_ip_target, object_identifier)
+                        
+                        # Add point to device
+                        device.points.append(point)
+                        logger.debug(f"Added point: {point_name} ({object_identifier})")
+                        
+                    except Exception as e:
+                        logger.error(f"Error processing point {object_identifier}: {e}")
+                
+                # Update UI after each page to show progress
+                points_processed += points_in_page
+                points_processed_so_far = min(points_processed, total_points_amount)
+                
+                async with self:
+                    self.discovered_devices[device_index] = device
+                    self.all_device_scan_point_status[status_id].message = f"Scanned {points_processed_so_far} of {total_points_amount} points"
+                    self.all_device_scan_point_status[status_id].percent_finished = int(points_processed_so_far / total_points_amount * 100)
+                yield BacnetScanState.update_ui()
+                
+                # Optional: Add a small delay to avoid overwhelming the device
+                await asyncio.sleep(0.5)
+                
+            # Update status to show completion
+            async with self:
+                self.all_device_scan_point_status[status_id].message = f"Completed scan of {len(device.points)} points for {device_name}"
+                self.all_device_scan_point_status[status_id].percent_finished = 100
+            yield BacnetScanState.update_ui()
+            
+        except Exception as e:
+            logger.error(f"Failed during point scan: {e}")
+            async with self:
+                self.all_device_scan_point_status[status_id].message = f"Error during scan: {str(e)}"
+                self.all_device_scan_point_status[status_id].percent_finished = 100
+            yield BacnetScanState.update_ui()
+        
+        logger.debug(f"Completed background point scan for device {device.scanned_ip_target}")
+        
+        # Final UI update
+        yield BacnetScanState.update_ui()
+        
+        # Remove status after 5 seconds
+        await asyncio.sleep(5)
+        async with self:
+            if status_id < len(self.all_device_scan_point_status):
+                self.all_device_scan_point_status.pop(status_id)
+        yield BacnetScanState.update_ui()
+
+    @rx.event
+    def update_ui(self): yield
+        
     # For points pagination
     @rx.event
     def next_point_page(self):
@@ -2057,6 +2336,7 @@ class BacnetScanState(rx.State):
         self.point_table_filter = BACnetPointTableFilter(
             **change
         )
+        self._selected_points_page_number = 1
 
     @rx.event
     def toggle_select_all_points(self, checked: bool):
@@ -2374,6 +2654,7 @@ class BacnetScanState(rx.State):
     @rx.event
     async def handle_scan_ip_range(self):
         """Handle the Scan IP Range form submission."""
+        from bacnet_scan_tool.models import ScanResponse
         if not self.proxy_up:
             yield rx.toast.error("Proxy must be started first.")
             return
@@ -2382,250 +2663,51 @@ class BacnetScanState(rx.State):
         yield
         
         try:
-            scan_results: BACnetScanResults = await scan_bacnet_ip_range(self.scan_ip_range.network_string)
+            scan_results: ScanResponse = await scan_bacnet_subnet(self.scan_ip_range.network_string)
             
             # Get devices 
             devices = [
                 BACnetDeviceModelView(
-                **device.model_dump(),
-                ) for device in scan_results.devices
+                    deviceIdentifier = device.deviceIdentifier,
+                    device_instance=device.device_instance,
+                    scanned_ip_target = device.address,
+                    vendorId = device.vendorID,
+                )
+                for device in scan_results.devices
             ]
+            logger.debug(f"devices we found: {devices}")
 
             # Read device all on each of our devices[]
-            for device in devices:
+            for device_index, device in enumerate(devices):
                 logger.debug(f"this is our device we are operating on: {device}")
-
                 try:            
                     res = await read_bacnet_device_all(
                             BACnetReadDeviceAllRequest(
                                 device_address=device.scanned_ip_target,
                                 device_object_identifier=device.deviceIdentifier
-                            )
+                            ),
+                            timeout=30.0
                         )
                     if res.get("status") == "error":
                         logger.debug(f"this is our res: {res}")
                         raise Exception(f"Error occurred calling api though thin endpoint wrapper")
                 except Exception as e:
                     import traceback
-                    logger.debug(f"An error occurred running scan: {traceback.format_exc()}")
-                    break
-
+                    logger.debug(f"An error occurred reading device {device.scanned_ip_target}: {traceback.format_exc()}")
+                    device.object_name="UNKNOWN"
+                    device.read_device_all_failed = True
+                    continue  # Skip this device and move to the next one instead of breaking
+                
+                # Only execute these lines if the device was successfully read
+                device.object_name = res["properties"].get("object-name", "UNKNOWN")
                 points: list = res["properties"]["object-list"]
-                logger.debug(f"we are going to go through {len(points) - 1}")
-                logger.debug(f"sike we only getting 50")
-                # go through each object-list item, skip the first one which is ours, then read property the stuff
-                for obj in points[1:56]:
-                    logger.debug(f"Processing object: {obj}")
-                    
-                    object_identifier: str = f"{obj[0]},{obj[1]}"
-                    logger.debug(f"Created object_identifier: {object_identifier}")
-                    
-                    writable: bool = self.writable_map[obj[0]].writable
-                    logger.debug(f"Object type {obj[0]} is writable: {writable}")
-                    
-                    # Getting point name
-                    logger.debug(f"Step 1: Getting point name for {object_identifier} at {device.scanned_ip_target}")
-                    point_name_response = await read_bacnet_property(
-                        BACnetReadPropertyRequest(
-                            device_address=device.scanned_ip_target,
-                            object_identifier=object_identifier,
-                            property_identifier="object-name"
-                        )
-                    )
-                    logger.debug(f"Point name response received: {point_name_response}")
-                    point_name = point_name_response["result"]["_value"]
-                    logger.debug(f"Point name extracted: {point_name}")
-                    
-                    # Getting units
-                    logger.debug(f"Step 2: Getting units for {object_identifier} at {device.scanned_ip_target}")
-                    try:
-                        units_response = await read_bacnet_property(
-                            BACnetReadPropertyRequest(
-                                device_address=device.scanned_ip_target,
-                                object_identifier=object_identifier,
-                                property_identifier="units"
-                            )
-                        )
-                        logger.debug(f"Units response received: {units_response}")
-                        units = units_response["result"]["_value"]
-                        logger.debug(f"Units extracted: {units}")
-                    except Exception as e:
-                        logger.error(f"Failed to get units: {e}")
-                        units = "unknown"
-                        logger.debug(f"Using default units: {units}")
-                    
-                    # Getting present value
-                    logger.debug(f"Step 3: Getting present value for {object_identifier} at {device.scanned_ip_target}")
-                    try:
-                        present_value_response = await read_bacnet_property(
-                            BACnetReadPropertyRequest(
-                                device_address=device.scanned_ip_target,
-                                object_identifier=object_identifier,
-                                property_identifier="present-value"
-                            )
-                        )
-                        logger.debug(f"Present value response received: {present_value_response}")
-                        present_value = present_value_response["result"]["_value"]
-                        logger.debug(f"Present value extracted: {present_value}")
-                    except Exception as e:
-                        logger.error(f"Failed to get present value: {e}")
-                        present_value = "N/A"
-                        logger.debug(f"Using default present value: {present_value}")
-                    
-                    # Getting Notes
-                    logger.debug(f"Step 4: Getting notes for {object_identifier} at {device.scanned_ip_target}")
-                    try:
-                        notes_value_response = await read_bacnet_property(
-                            BACnetReadPropertyRequest(
-                                device_address=device.scanned_ip_target,
-                                object_identifier=object_identifier,
-                                property_identifier="notes"
-                            ),
-                            timeout=4.0
-                        )
-                        logger.debug(f"Notes value response received: {notes_value_response}")
-                        notes_value = notes_value_response["result"]["_value"]
-                        logger.debug(f"Notes value extracted: {notes_value}")
-                    except Exception as e:
-                        logger.error(f"Failed to get notes value: {e}")
-                        notes_value = ""
-                        logger.debug(f"Using default notes value: {notes_value}")
-
-                    logger.debug(f"Step 5: Getting index for {object_identifier} at {device.scanned_ip_target}")
-                    try:
-                        index_value = obj[1]
-                        logger.debug(f"Index value response received: {index_value}")
-                        logger.debug(f"Index value extracted: {index_value}")
-                    except Exception as e:
-                        logger.error(f"Failed to get index value: {e}")
-                        index_value = "N/A"
-                        logger.debug(f"Using default index value: {index_value}")
-
-                    logger.debug(f"Step 6: Getting object type for {object_identifier} at {device.scanned_ip_target}")
-                    try:
-                        object_type = self.writable_map[obj[0]].type_name
-                        logger.debug(f"Index value response received: {object_type}")
-                        logger.debug(f"Index value extracted: {object_type}")
-                    except Exception as e:
-                        logger.error(f"Failed to get index value: {e}")
-                        object_type = "N/A"
-                        logger.debug(f"Using default index value: {object_type}")
-
-
-                    # Create and add the point to device
-                    logger.debug(f"Step 7: Creating point model for {point_name}")
-                    point = BACnetDevicePointModelView(
-                        device_name=point_name,
-                        volttron_point_name=point_name,
-                        writable=writable,
-                        present_value=present_value,
-                        units=units,
-                        notes=notes_value,
-                        index=index_value,
-                        object_type=object_type,
-
-                        never_writable=obj[0] in self.NEVER_WRITABLE
-                    )
-                    point.safe_point = point.to_dict()
-                    point.set_write_request_target(device.scanned_ip_target, object_identifier)
-                    logger.debug(f"Point created: {point}")
-                    
-                    logger.debug(f"Step 8: Adding point to device {device}")
-                    device.points.append(point)
-                    logger.debug(f"Point added to device successfully. Device now has {len(device.points)} points.")
-
-
-# # =============================MANUALLY ADDING POINT==============================
-#             logger.debug(f"Manually adding one more point... 2,3000112")
-#             index="3000112"
-#             object_type=self.writable_map[2].type_name
-#             object_identifier="2,{index}"
-#             writable=self.writable_map[2].writable
-
-#             # Getting our point Manually. 
-#             logger.debug(f"Step 1: Getting point name for {object_identifier} at {device.scanned_ip_target}")
-#             point_name_response = await read_bacnet_property(
-#                 BACnetReadPropertyRequest(
-#                     device_address=device.scanned_ip_target,
-#                     object_identifier=object_identifier,
-#                     property_identifier="object-name"
-#                 )
-#             )
-#             logger.debug(f"Point name response received: {point_name_response}")
-#             point_name = point_name_response["result"]["_value"]
-#             logger.debug(f"Point name extracted: {point_name}")
-            
-#             # Getting units
-#             logger.debug(f"Step 2: Getting units for {object_identifier} at {device.scanned_ip_target}")
-#             try:
-#                 units_response = await read_bacnet_property(
-#                     BACnetReadPropertyRequest(
-#                         device_address=device.scanned_ip_target,
-#                         object_identifier=object_identifier,
-#                         property_identifier="units"
-#                     )
-#                 )
-#                 logger.debug(f"Units response received: {units_response}")
-#                 units = units_response["result"]["_value"]
-#                 logger.debug(f"Units extracted: {units}")
-#             except Exception as e:
-#                 logger.error(f"Failed to get units: {e}")
-#                 units = "unknown"
-#                 logger.debug(f"Using default units: {units}")
-            
-#             # Getting present value
-#             logger.debug(f"Step 3: Getting present value for {object_identifier} at {device.scanned_ip_target}")
-#             try:
-#                 present_value_response = await read_bacnet_property(
-#                     BACnetReadPropertyRequest(
-#                         device_address=device.scanned_ip_target,
-#                         object_identifier=object_identifier,
-#                         property_identifier="present-value"
-#                     )
-#                 )
-#                 logger.debug(f"Present value response received: {present_value_response}")
-#                 present_value = present_value_response["result"]["_value"]
-#                 logger.debug(f"Present value extracted: {present_value}")
-#             except Exception as e:
-#                 logger.error(f"Failed to get present value: {e}")
-#                 present_value = "N/A"
-#                 logger.debug(f"Using default present value: {present_value}")
-            
-#             # Getting Notes
-#             logger.debug(f"Step 4: Getting notes for {object_identifier} at {device.scanned_ip_target}")
-#             try:
-#                 notes_value_response = await read_bacnet_property(
-#                     BACnetReadPropertyRequest(
-#                         device_address=device.scanned_ip_target,
-#                         object_identifier=object_identifier,
-#                         property_identifier="notes"
-#                     ),
-#                     timeout=4.0
-#                 )
-#                 logger.debug(f"Notes value response received: {notes_value_response}")
-#                 notes_value = notes_value_response["result"]["_value"]
-#                 logger.debug(f"Notes value extracted: {notes_value}")
-#             except Exception as e:
-#                 logger.error(f"Failed to get notes value: {e}")
-#                 notes_value = ""
-#                 logger.debug(f"Using default notes value: {notes_value}")
-
-
-#             logger.debug(f"Step 5: Creating point model for {point_name}")
-#             point = BACnetDevicePointModelView(
-#                 device_name=point_name,
-#                 volttron_point_name=point_name,
-#                 writable=writable,
-#                 present_value=present_value,
-#                 units=units,
-#                 notes=notes_value,
-#                 index=index,
-#                 object_type=object_type
-#             )
-#             point.safe_point = point.to_dict()
-#             point.set_write_request_target(device.scanned_ip_target, object_identifier)
-#             device.points.append(point)
-# # ======================================================================================
+                points_amount: int = len(points) - 1
+                logger.debug(f"we have {points_amount} points to scan for on device {device.scanned_ip_target}")
+                # logger.debug(f"we are going to go through {len(points) - 1}")
+                # logger.debug(f"sike we only getting 50")
+                
+                # Launch background task to scan for points
+                yield BacnetScanState.scan_for_points(device, device_index, points_amount) 
 
             logger.debug(f"this is our scan results: {scan_results}")
             self.discovered_devices = devices
@@ -2719,38 +2801,33 @@ class BacnetScanState(rx.State):
 
     # Other
     @rx.event
-    def select_platform_for_registry_config(self, uid: str):
+    async def select_platform_for_registry_config(self, uid: str):
         self.selected_platform_uid = uid if self.selected_platform_uid != uid else ""
 
+        platform_state = await self.get_state(PlatformPageState)
+        platform = platform_state.platforms.get(uid)
+        if not platform:
+            self._platform_has_platform_driver = True
+            return
+        
+        self._platform_has_platform_driver = "platform.driver" in platform.platform.agents
+        return
+
     @rx.event
-    async def on_add_to_registry_config(self):
-        yield BacnetScanState.close_dialogs()
-        csv_data = self._convert_selected_points_to_csv()
-        escaped_csv_data = csv_data.replace("'", "\\'")
+    def on_add_to_registry_config_confirm(self, form_data):
+        """Handle the confirmation to add selected points to registry config."""
+        if self.selected_platform_uid == "":
+            # yield rx.toast.error("No platform selected for registry config.")
+            return
         
-        platform_page_state: PlatformPageState = await self.get_state(PlatformPageState)
-        
-        # Check if platform.driver is NOT on the selected platform
-        if "platform.driver" not in list(platform_page_state.platforms[self.selected_platform_uid].platform.agents.keys()):
-            logger.debug("Platform.driver agent not found on platform, adding it...")
-            # Find and add platform driver agent to the platform
-            for agent in platform_page_state.list_of_agents:
-                if agent.identity == "platform.driver":
-                    logger.debug("Found platform.driver agent in list of agents, adding to platform...")
-                    yield PlatformPageState.handle_adding_agent(agent, self.selected_platform_uid)
-                    break
-            else:
-                logger.debug("No platform.driver agent found in the list of agents. Somehow...")
-        else:
-            logger.debug("Platform.driver agent already exists on platform")
-        
-        logger.debug("Adding registry config to platform...")
-        yield BacnetScanState.add_registry_config_to_platform(self.selected_platform_uid, "points.csv", escaped_csv_data)
-        
-    # TODO move all the stuff handiling adding the actual config store entry to its designated state and method
-    @rx.event
-    async def on_add_to_registry_config(self):
-        """Add selected BACnet points to a platform.driver registry configuration."""
+        logger.debug(f"selected platform UID: {self.selected_platform_uid}")
+        platform_uid = self.selected_platform_uid
+
+        path = form_data.get("path", "")
+        if path == "":
+            yield rx.toast.error("Path cannot be empty.")
+            return
+
         # Close any open dialogs
         yield BacnetScanState.close_dialogs()
         
@@ -2758,7 +2835,16 @@ class BacnetScanState(rx.State):
         csv_data = self._convert_selected_points_to_csv()
         escaped_csv_data = csv_data.replace("'", "\\'")
         
-        platform_uid = self.selected_platform_uid
+        # Add the registry config to the platform
+        yield BacnetScanState.on_add_to_registry_config(platform_uid, path, escaped_csv_data)
+
+    # TODO move all the stuff handiling adding the actual config store entry to its designated state and method
+    @rx.event
+    async def on_add_to_registry_config(self, platform_uid: str, path: str, escaped_csv_data: str):
+        """Add selected BACnet points to a platform.driver registry configuration."""
+        # Close any open dialogs
+        yield BacnetScanState.close_dialogs()
+                
         
         # Step 1: Ensure platform.driver agent exists
         # yield BacnetScanState.ensure_platform_driver_exists(platform_uid)
@@ -2766,6 +2852,8 @@ class BacnetScanState(rx.State):
         platform_page_state: PlatformPageState = await self.get_state(PlatformPageState)
         platform = platform_page_state.platforms.get(platform_uid)
         if not platform:
+            logger.debug(f"Platform with UID {platform_uid} not found.")
+            logger.debug(f"Available platforms: {list(platform_page_state.platforms.keys())}")
             yield rx.toast.error("Platform not found")
             return
         
@@ -2776,14 +2864,11 @@ class BacnetScanState(rx.State):
                     yield PlatformPageState.handle_adding_agent(agent, platform_uid)
         # ===============================================================
 
-
-
-
-
         # Step 2: Add the registry config to the platform.driver agent
         yield BacnetScanState.add_config_to_platform_driver(
             platform_uid, 
-            escaped_csv_data
+            escaped_csv_data,
+            path
         )
 
     @rx.event
@@ -2816,7 +2901,8 @@ class BacnetScanState(rx.State):
     async def add_config_to_platform_driver(
         self, 
         platform_uid: str, 
-        csv_value: str
+        csv_value: str,
+        path: str
     ):
         """Add a config store entry with the CSV value to the platform.driver agent."""
         platform_page_state: PlatformPageState = await self.get_state(PlatformPageState)
@@ -2833,7 +2919,7 @@ class BacnetScanState(rx.State):
 
         # Create and add the config store entry
         component_id = generate_unique_uid()
-        config_entry = self._create_config_store_entry("points.csv", csv_value, component_id)
+        config_entry = self._create_config_store_entry(path, csv_value, component_id)
         driver_agent.config_store.append(config_entry)
         
         # Finalize the agent
@@ -2992,7 +3078,12 @@ class BacnetScanState(rx.State):
         for point in self.selected_points:
             point_dict = point.dict() if hasattr(point, "dict") else point.__dict__
             row = []
-            for _, field in columns:
+            for header_cell, field in columns:
+                if header_cell == "Property":
+                    value = "presentValue"
+                    row.append(value)
+                    continue
+
                 value = point_dict.get(field, "")
                 if isinstance(value, bool):
                     value = "TRUE" if value else "FALSE"

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -2120,12 +2120,12 @@ class BacnetScanState(rx.State):
         yield
         self.selected_device.points[absolute_index].safe_point = self.selected_device.points[absolute_index].to_dict()
         yield
-        yield BacnetScanState.handle_write_property(
-            self.selected_device.points[absolute_index],
-            "present-value",
-            self.selected_device.points[absolute_index].safe_point["present_value"],
-            1
-        )
+        # yield BacnetScanState.handle_write_property(
+        #     self.selected_device.points[absolute_index],
+        #     "present-value",
+        #     self.selected_device.points[absolute_index].safe_point["present_value"],
+        #     1
+        # )
 
 
     @rx.event
@@ -2199,7 +2199,9 @@ class BacnetScanState(rx.State):
         if not self.proxy_up:
             yield rx.toast.error("Proxy must be started first.")
             return
+        yield
         self.scanning_bacnet_range = True
+        yield
         
         try:
             scan_results: BACnetScanResults = await scan_bacnet_ip_range(self.scan_ip_range.network_string)

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -1979,14 +1979,20 @@ class BacnetScanState(rx.State):
     @rx.event
     def cancel_device_point_present_value_edit(self, index: int):
         absolute_index = self.get_absolute_index(index)
-        self.selected_device.points[index].present_value = self.selected_device.points[absolute_index].safe_point["present_value"]
         yield BacnetScanState.disable_device_point_present_value_edit(index)
+        logger.debug(f"this is the safe point: {self.selected_device.points[absolute_index].safe_point}")
+        yield
+        self.selected_device.points[absolute_index].present_value = self.selected_device.points[absolute_index].safe_point['present_value']
+        yield
 
     @rx.event
     def save_device_point_present_value_edit(self, index: int):
         absolute_index = self.get_absolute_index(index)
-        self.selected_device.points[index].safe_point = self.selected_device.points[absolute_index].to_dict()
         yield BacnetScanState.disable_device_point_present_value_edit(index)
+        logger.debug(f"this is the safe point: {self.selected_device.points[absolute_index].safe_point}")
+        yield
+        self.selected_device.points[absolute_index].safe_point = self.selected_device.points[absolute_index].to_dict()
+        yield
         # yield method to write to point
 
     # Handle the actual endpoint actions/functionality

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -1576,6 +1576,7 @@ def __create_prefilled_bacnet_device__() -> BACnetDeviceModelView:
             selected=False,
             present_value_editing=False,
             volttron_point_name_editing=False,
+            never_writable=True,
             safe_point={},
         ),
         BACnetDevicePointModelView(
@@ -1710,12 +1711,19 @@ class BacnetScanState(rx.State):
     windows_host_ip_info: WindowsHostIPModel = WindowsHostIPModel()
 
     # For bacnet point stuff
+    NEVER_WRITABLE: list[int] = [
+        0,
+        3,
+        8,
+        13,
+        37
+    ]
     writable_map: Dict[int, BACnetObjectType] = {
         # INPUTS NEVER, some maybe
-        0: BACnetObjectType(value=0, type_name="analog-input", writable=False),
+        0: BACnetObjectType(value=0, type_name="analog-input", writable=False), # NEVER
         1: BACnetObjectType(value=1, type_name="analog-output", writable=True),
         2: BACnetObjectType(value=2, type_name="analog-value", writable=True),
-        3: BACnetObjectType(value=3, type_name="binary-input", writable=False),
+        3: BACnetObjectType(value=3, type_name="binary-input", writable=False), # NEVER
         4: BACnetObjectType(value=4, type_name="binary-output", writable=True),
         5: BACnetObjectType(value=5, type_name="binary-value", writable=True),
         6: BACnetObjectType(value=6, type_name="calendar", writable=True),
@@ -1725,7 +1733,7 @@ class BacnetScanState(rx.State):
         10: BACnetObjectType(value=10, type_name="file", writable=False),
         11: BACnetObjectType(value=11, type_name="group", writable=False),
         12: BACnetObjectType(value=12, type_name="loop", writable=False),
-        13: BACnetObjectType(value=13, type_name="multi-state-input", writable=False),
+        13: BACnetObjectType(value=13, type_name="multi-state-input", writable=False), # NEVER
         14: BACnetObjectType(value=14, type_name="multi-state-output", writable=True),
         15: BACnetObjectType(value=15, type_name="notification-class", writable=True),
         16: BACnetObjectType(value=16, type_name="program", writable=True),
@@ -1749,7 +1757,7 @@ class BacnetScanState(rx.State):
         34: BACnetObjectType(value=34, type_name="access-rights", writable=False),
         35: BACnetObjectType(value=35, type_name="access-user", writable=False),
         36: BACnetObjectType(value=36, type_name="access-zone", writable=False),
-        37: BACnetObjectType(value=37, type_name="credentional-data-input", writable=False),
+        37: BACnetObjectType(value=37, type_name="credentional-data-input", writable=False), # NEVER
         38: BACnetObjectType(value=38, type_name="network-security", writable=False),
         39: BACnetObjectType(value=39, type_name="bitstring-value", writable=False),
         40: BACnetObjectType(value=40, type_name="characterstring-value", writable=False),
@@ -2268,6 +2276,16 @@ class BacnetScanState(rx.State):
         #     1
         # )
 
+    @rx.event
+    def flip_device_point_writable(self, index: int):
+        """Toggle the writable state of a device point."""
+        index = self.get_absolute_index(index)
+        point = self.selected_device.points[index]
+        point.writable = not point.writable
+        # Update the writable map for this object type
+        if point.object_type in self.writable_map:
+            self.writable_map[point.object_type].writable = point.writable
+
 
     @rx.event
     def handle_volttron_point_name_value_edit(self, index: int, value: str):
@@ -2485,7 +2503,9 @@ class BacnetScanState(rx.State):
                         units=units,
                         notes=notes_value,
                         index=index_value,
-                        object_type=object_type
+                        object_type=object_type,
+
+                        never_writable=obj[0] in self.NEVER_WRITABLE
                     )
                     point.safe_point = point.to_dict()
                     point.set_write_request_target(device.scanned_ip_target, object_identifier)

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -2074,7 +2074,7 @@ class BacnetScanState(rx.State):
                                     object_identifier=f"{type_int},{index_value}",
                                     property_identifier="notes"
                                 ),
-                                timeout=4.0
+                                TIMEOUT=0.05
                             )
                             data = res_notes.json()
                             
@@ -2472,12 +2472,12 @@ class BacnetScanState(rx.State):
         yield
         self.selected_device.points[absolute_index].safe_point = self.selected_device.points[absolute_index].to_dict()
         yield
-        # yield BacnetScanState.handle_write_property(
-        #     self.selected_device.points[absolute_index],
-        #     "present-value",
-        #     self.selected_device.points[absolute_index].safe_point["present_value"],
-        #     1
-        # )
+        yield BacnetScanState.handle_write_property(
+            self.selected_device.points[absolute_index],
+            "present-value",
+            self.selected_device.points[absolute_index].safe_point["present_value"],
+            8
+        )
 
     @rx.event
     def flip_device_point_writable(self, index: int):
@@ -2653,7 +2653,7 @@ class BacnetScanState(rx.State):
         self, 
         point: BACnetDevicePointModelView, 
         property_identifier: str, 
-        value: Any, 
+        value: Any,
         priority: int, 
         property_array_index: int | None = None
     ):
@@ -2661,19 +2661,36 @@ class BacnetScanState(rx.State):
         if not self.proxy_up:
             yield rx.toast.error("Proxy must be started first.")
             return
+        identfier = point.write_request_target.get("object_identifier", "")
+        if identfier != "analog-value,3000112":
+            logger.debug(f"We cant continue. point is not safe to write: {identfier}")
+            return
+    
+        try:
+            val = float(value)
+            if 69 <= val <= 76:
+                logger.debug(f"we are valid to write: {val}")
+                value = val
+            else:
+                logger.debug(f"value is not in range to write for the point.")
+                value = 71
+                return
+        except Exception as e:
+            logger.error(f"{e}")
+            value = 71
             
         yield rx.toast.info(f"Writing to property on {self.write_property.device_address}")
-        
+
         try:
             logger.debug(f"Writing bacnet property: {property_identifier}, to target: {point.write_request_target}, value: {value}")
             response = await write_bacnet_property(
                 BACnetWritePropertyRequest(
-                    # **point.write_request_target,
-                    device_address="130.20.24.157",
-                    object_identifier="2,3000112",
+                    **point.write_request_target,
+                    # device_address="130.20.24.157",
+                    # object_identifier="2,3000112",
                     # ==============================
-                    property_identifier="present-value",
-                    value=71.0,
+                    property_identifier=property_identifier,
+                    value=value,
                     priority=priority
                     # Omit property_array_index for now 
                 )

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -518,8 +518,8 @@ class PlatformPageState(rx.State):
 
     # Events
     @rx.event
-    async def hydrate_state(self):
-        if self.session_hydrated == False:
+    async def hydrate_state(self, force_hydration: bool = False):
+        if self.session_hydrated == False or force_hydration:
             # Make sure we have a valid 'blank' agent
             blank_agent = AgentModelView(
                     safe_agent={
@@ -790,6 +790,7 @@ class PlatformPageState(rx.State):
         yield NavigationState.route_to_platform(working_platform.platform.config.instance_name)
         logger.debug(f"this is the uid about to deletee: {uid_copy}")
         yield PlatformPageState.delete_temp_uid(uid_copy)
+        yield PlatformPageState.hydrate_state(True)
 
     @rx.event
     async def determine_host_reachability(self, working_platform: Instance):

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -2295,7 +2295,7 @@ class BacnetScanState(rx.State):
             yield rx.toast.info(f"Selected device: {selected_device.object_name}")
     
     @rx.event
-    def set_ip_detection_mode(self, mode: Literal["windows_host_ip", "local_ip"]):
+    def set_ip_detection_mode(self, mode: Literal["host_ip", "local_ip"]):
         """Switch between local IP and Windows host IP mode."""
         self.ip_detection_mode = mode
         yield BacnetScanState.get_network_info()
@@ -2699,8 +2699,8 @@ class BacnetScanState(rx.State):
     @rx.event
     async def handle_get_windows_host_ip(self):
         try:
-            self.windows_host_ip_info = await get_windows_host_ip()
-            self.scan_ip_range.network_string = self.windows_host_ip_info.windows_host_ip.rsplit('.', 1)[0] + ".0/24" # Split at the last period, max 1 split. tack it off with cidr range
+            self.windows_host_ip_info = await get_bacnet_host_ip()
+            self.scan_ip_range.network_string = self.windows_host_ip_info.address.rsplit('.', 1)[0] + ".0/24" # Split at the last period, max 1 split. tack it off with cidr range
             yield rx.toast.success("Retrieved Host IP")
         except Exception as e:
             logger.debug(f"There was an error getting local ip info {e}")

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -2236,7 +2236,7 @@ class BacnetScanState(rx.State):
                 logger.debug(f"we are going to go through {len(points) - 1}")
                 logger.debug(f"sike we only getting 50")
                 # go through each object-list item, skip the first one which is ours, then read property the stuff
-                for obj in points[1:81]:
+                for obj in points[1:56]:
                     logger.debug(f"Processing object: {obj}")
                     
                     object_identifier: str = f"{obj[0]},{obj[1]}"

--- a/volttron_installer/thin_endpoint_wrappers/__init__.py
+++ b/volttron_installer/thin_endpoint_wrappers/__init__.py
@@ -254,10 +254,10 @@ async def read_bacnet_property(request: BACnetReadPropertyRequest, TIMEOUT: floa
     )
     return response.json()
 
-async def write_bacnet_property(request: BACnetWritePropertyRequest) -> dict[str, str]:
+async def write_bacnet_property(request: BACnetWritePropertyRequest):
     """Write a property to a BACnet device."""
     from loguru import logger
-    logger.debug(request.model_dump())
+    logger.debug(f"we got hit with: {request.model_dump()}")
     response = await proxy_request(
         f"{API_BASE_URL}{BACNET_SCAN_TOOL_PREFIX}/write_property",
         "POST",

--- a/volttron_installer/thin_endpoint_wrappers/__init__.py
+++ b/volttron_installer/thin_endpoint_wrappers/__init__.py
@@ -5,9 +5,11 @@ from ..backend.models import AgentType, HostEntry, PlatformDefinition, \
     CreatePlatformRequest, CreateOrUpdateHostEntryRequest, ReachableResponse, \
     PlatformDeploymentStatus, CreateAgentRequest, ToolRequest, ToolStatusResponse, \
     BACnetReadDeviceAllRequest, BACnetDevice, BACnetReadPropertyRequest, BACnetScanResults, \
-    BACnetWritePropertyRequest
+    BACnetWritePropertyRequest, BACnetReadObjectListRequest
 from ..models import WindowsHostIPModel, LocalIPModel
 from rxconfig import config
+
+from bacnet_scan_tool.models import ScanResponse, ObjectListNamesResponse
 
 API_BASE_URL = f"{config.api_url}"
 API_PREFIX = "/api"
@@ -234,14 +236,24 @@ async def start_bacnet_proxy(local_device_address: str = None) -> dict[str, str]
     response = await proxy_request(f"{API_BASE_URL}{BACNET_SCAN_TOOL_PREFIX}/start_proxy", "POST", params=data)
     return response.json()
 
-@with_model(BACnetScanResults)
-async def scan_bacnet_ip_range(network_str: str) -> BACnetScanResults:
+@with_model(ScanResponse)
+async def scan_bacnet_subnet(network_str: str) -> ScanResponse:
     """Scan a BACnet IP range for devices."""
     return await proxy_request(
-        f"{API_BASE_URL}{BACNET_SCAN_TOOL_PREFIX}/bacnet/scan_ip_range",
+        f"{API_BASE_URL}{BACNET_SCAN_TOOL_PREFIX}/bacnet/scan_subnet",
         "POST",
         timeout=600.0,
         params={"network_str": network_str}
+    )
+
+@with_model(ObjectListNamesResponse)
+async def read_bacnet_object_list_names(request: BACnetReadObjectListRequest) -> ObjectListNamesResponse:
+    """Read object list names from a BACnet device."""
+    return await proxy_request(
+        f"{API_BASE_URL}{BACNET_SCAN_TOOL_PREFIX}/bacnet/read_object_list_names",
+        "POST",
+        timeout=60.0,
+        params=request.model_dump()
     )
 
 async def read_bacnet_property(request: BACnetReadPropertyRequest, TIMEOUT: float=60.0):
@@ -265,7 +277,7 @@ async def write_bacnet_property(request: BACnetWritePropertyRequest):
     )
     return response.json()
 
-async def read_bacnet_device_all(request: BACnetReadDeviceAllRequest) -> dict:
+async def read_bacnet_device_all(request: BACnetReadDeviceAllRequest, timeout: float = 600.0) -> dict:
     """Read all properties from a BACnet device."""
     try:
         from loguru import logger
@@ -273,7 +285,7 @@ async def read_bacnet_device_all(request: BACnetReadDeviceAllRequest) -> dict:
         response = await proxy_request(
             f"{API_BASE_URL}{BACNET_SCAN_TOOL_PREFIX}/bacnet/read_device_all",
             "POST",
-            timeout=600.0,
+            timeout=timeout,
             json=request.model_dump()
         )
         return response.json()

--- a/volttron_installer/thin_endpoint_wrappers/__init__.py
+++ b/volttron_installer/thin_endpoint_wrappers/__init__.py
@@ -212,9 +212,9 @@ async def get_bacnet_local_ip(target_ip: str = None) -> LocalIPModel:
     return await proxy_request(f"{API_BASE_URL}{BACNET_SCAN_TOOL_PREFIX}/get_local_ip", "GET", params=params)
 
 @with_model(WindowsHostIPModel)
-async def get_windows_host_ip() -> WindowsHostIPModel:
+async def get_bacnet_host_ip() -> WindowsHostIPModel:
     """Get Windows host IP address for WSL2 users."""
-    return await proxy_request(f"{API_BASE_URL}{BACNET_SCAN_TOOL_PREFIX}/get_windows_host_ip", "GET")
+    return await proxy_request(f"{API_BASE_URL}{BACNET_SCAN_TOOL_PREFIX}/get_host_ip", "GET")
 
 async def get_tool_proxy(tool_name: str, path: str, **kwargs) -> httpx.Response:
     return await proxy_request(f"{API_BASE_URL}{TOOL_PROXY_PREFIX}/{tool_name}/{path}", "GET", **kwargs)


### PR DESCRIPTION
Fairly big pr unfortunately which covers a lot of stuff. This Pr includes the latest bacnet scan tool endpoints and models with individual endpoint wrappers to accompany the new endpoints. 

**Features**
- Export to CSV button that displays the users selected points before prompting a Save As dialog:
  - <img width="1919" height="865" alt="image" src="https://github.com/user-attachments/assets/43bb1db1-d304-483e-adc6-99082770d2c6" />
- Create a registry config button with the following workflow after selecting points.
  - Confirm csv contents: 
  - <img width="1919" height="862" alt="image" src="https://github.com/user-attachments/assets/4fc7a30b-dc44-4f4d-bd4f-c772d452f174" />
  - Select platform and provide a path (defaulted to points.csv): 
  - <img width="1919" height="858" alt="image" src="https://github.com/user-attachments/assets/92943783-b28d-49fd-a6b3-738639f8f901" />
  - Duplicate paths provided via this text field returns an error, "Path is already in use."

- On scan of a subnet, each device will have a status bar at the top of the page displaying how many points are being scanned in the background: 
   - <img width="1919" height="860" alt="image" src="https://github.com/user-attachments/assets/540b5992-f525-442b-b374-c952a013daf2" />

- Pagination of 20 points per page

- Filtering system that gets the intersection of all the filters applied (also works with the pagination) (filtering doesn't apply to hidden columns).
  - <img width="1917" height="862" alt="image" src="https://github.com/user-attachments/assets/2155675d-8163-4924-8940-3da11ac6d5cd" />

- On submit of editing a present value cell, the write property endpoint is called in the bacnet scan tool.



Closes #94 
Closes #105 
Closes #106 