### PR TITLE
issue/96 tie tool inactivity timeout to dev.env settings

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -7,3 +7,4 @@ BACKEND_PORT = 8000
 BASE_URL = http://localhost
 API_URL = ${BASE_URL}:${BACKEND_PORT}
 TOOL_PROXY_URL = "http://localhost"
+TOOL_INACTIVITY_TIMEOUT = 30

--- a/volttron_installer/backend/__init__.py
+++ b/volttron_installer/backend/__init__.py
@@ -6,7 +6,7 @@ from .tool_manager import ToolManager
 import os
 
 def init(app: FastAPI | rx.App):
-    ToolManager.set_inactivity_timeout(os.environ.get("TOOL_INACTIVITY_TIMEOUT", 30))
+    ToolManager.set_inactivity_timeout(int(os.environ.get("TOOL_INACTIVITY_TIMEOUT", 30)))
     
     # Reflex wraps fast API, make sure to set app to FastAPI instance
     if isinstance(app, rx.App):

--- a/volttron_installer/backend/__init__.py
+++ b/volttron_installer/backend/__init__.py
@@ -3,11 +3,26 @@ from fastapi import FastAPI
 from . import endpoints as api
 from .tool_router import tool_router
 from .tool_manager import ToolManager
+from loguru import logger
 import os
 
 def init(app: FastAPI | rx.App):
-    ToolManager.set_inactivity_timeout(int(os.environ.get("TOOL_INACTIVITY_TIMEOUT", 30)))
-    
+    # We grab the environment variable "TOOL_INACTIVITY_TIMEOUT" from our dev.env file. If value not present, we default to 30 seconds.
+    try:
+        timeout_value = os.environ.get("TOOL_INACTIVITY_TIMEOUT", "30")
+        # Convert to int, and handle potential ValueError if the string can't be converted
+        timeout_seconds = int(timeout_value)
+        if timeout_seconds <= 0:
+            # Validate that the timeout is positive
+            logger.warning(f"Invalid TOOL_INACTIVITY_TIMEOUT value: {timeout_value}. Using default of 30 seconds.")
+            timeout_seconds = 30
+    except ValueError:
+        # Handle case where the environment variable contains a non-integer value
+        logger.warning(f"Non-numeric TOOL_INACTIVITY_TIMEOUT value: {timeout_value}. Using default of 30 seconds.")
+        timeout_seconds = 30
+        
+    ToolManager.set_inactivity_timeout(timeout_seconds)
+
     # Reflex wraps fast API, make sure to set app to FastAPI instance
     if isinstance(app, rx.App):
         app = app.api

--- a/volttron_installer/backend/__init__.py
+++ b/volttron_installer/backend/__init__.py
@@ -3,9 +3,10 @@ from fastapi import FastAPI
 from . import endpoints as api
 from .tool_router import tool_router
 from .tool_manager import ToolManager
+import os
 
-def init(app: FastAPI | rx.App, inactivity_timeout_minutes: int = 30):
-    ToolManager.set_inactivity_timeout(inactivity_timeout_minutes)
+def init(app: FastAPI | rx.App):
+    ToolManager.set_inactivity_timeout(os.environ.get("TOOL_INACTIVITY_TIMEOUT", 30))
     
     # Reflex wraps fast API, make sure to set app to FastAPI instance
     if isinstance(app, rx.App):


### PR DESCRIPTION
Added a `TOOL_INACTIVITY_TIMEOUT` field to dev env settings. Ensured ToolManager receives the environment variable 
Fixes #96