### PR TITLE
Issue/121 create registry config workflow update

### DIFF
--- a/volttron_installer/models.py
+++ b/volttron_installer/models.py
@@ -124,3 +124,7 @@ class BACnetDevicePointScanStatus(rx.Base):
     message: str
     device_name: str
     percent_finished: int
+
+class SelectedPlatformForm(rx.Base):
+    path: str = ""
+    add_to_new_platform: bool = False

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -697,8 +697,12 @@ def add_to_registry_config_file_dialog() -> rx.Component:
                                             platform.platform.config.instance_name,
                                             platform,
                                             background_color=rx.cond(
-                                                BacnetScanState.selected_platform_uid == platform.platform.config.instance_name,
-                                                "#44C0ED",
+                                                BacnetScanState.selected_platform_uids.contains(platform.platform.config.instance_name),
+                                                rx.cond(
+                                                    BacnetScanState.platforms_with_platform_driver.contains(platform.platform.config.instance_name),
+                                                    "#44C0ED",
+                                                    "orange"
+                                                ),
                                                 "rgba(145, 145, 145, 0.29)"
                                             ),
                                             on_click=lambda: BacnetScanState.select_platform_for_registry_config(platform.platform.config.instance_name)
@@ -710,9 +714,9 @@ def add_to_registry_config_file_dialog() -> rx.Component:
                                     margin_top="24px",
                                 ),
                                 rx.cond(
-                                    BacnetScanState.platform_has_platform_driver == False,
+                                    BacnetScanState.platforms_with_platform_driver.length() != BacnetScanState.selected_platform_uids.length(),
                                     rx.text(
-                                        "This selected platform doesn't already contain a platform.driver agent, confirming will automatically add a platform.driver agent to the platform along side the registry config within it's config store.",
+                                        "One or more selected platforms don't already contain a platform.driver agent, confirming will automatically add a platform.driver agent to the platform along side the registry config within it's config store.",
                                         size="1",
                                         color="#ffa057",
                                         padding="8px 12px",
@@ -737,7 +741,7 @@ def add_to_registry_config_file_dialog() -> rx.Component:
                                     default_value="points.csv",
                                     name="path",
                                     disabled=rx.cond(
-                                        BacnetScanState.selected_platform_uid == "",
+                                        BacnetScanState.selected_platform_uids.length() == 0, # & make new platform checkbox is false
                                         True,
                                         False
                                     ),
@@ -770,7 +774,7 @@ def add_to_registry_config_file_dialog() -> rx.Component:
                             size="2",
                             type="submit",
                             disabled=rx.cond(
-                                BacnetScanState.selected_platform_uid == "",
+                                BacnetScanState.selected_platform_uids.length() == 0, # & add to new platform checkbox == false
                                 True,
                                 False
                             ),

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -714,7 +714,7 @@ def add_to_registry_config_file_dialog() -> rx.Component:
                                     margin_top="24px",
                                 ),
                                 rx.cond(
-                                    BacnetScanState.platforms_with_platform_driver.length() != BacnetScanState.selected_platform_uids.length(),
+                                    BacnetScanState.display_selected_platforms_warning,
                                     rx.text(
                                         "One or more selected platforms don't already contain a platform.driver agent, confirming will automatically add a platform.driver agent to the platform along side the registry config within it's config store.",
                                         size="1",
@@ -732,7 +732,7 @@ def add_to_registry_config_file_dialog() -> rx.Component:
                         ),
                         
                         # Second column (30%) - Form entry
-                        rx.box(
+                        rx.vstack(
                             form_entry.form_entry(
                                 "Path",
                                 rx.input(
@@ -748,6 +748,12 @@ def add_to_registry_config_file_dialog() -> rx.Component:
                                     required=True,
                                 ),
                                 required_entry=True,
+                            ),
+                            form_entry.form_entry(
+                                "Add to a new platform",
+                                rx.checkbox(
+                                    name="add_to_new_platform",
+                                ),
                             ),
                             width="100%",  # Take full width of this grid cell
                             margin_top="24px",

--- a/volttron_installer/pages/bacnet_scan.py
+++ b/volttron_installer/pages/bacnet_scan.py
@@ -734,6 +734,14 @@ def add_to_registry_config_file_dialog() -> rx.Component:
                         # Second column (30%) - Form entry
                         rx.vstack(
                             form_entry.form_entry(
+                                "Add to a new platform",
+                                rx.checkbox(
+                                    checked=BacnetScanState.selected_platform_form.add_to_new_platform,
+                                    on_change=lambda v: BacnetScanState.toggle_add_to_new_platform(v),
+                                    name="add_to_new_platform",
+                                ),
+                            ),
+                            form_entry.form_entry(
                                 "Path",
                                 rx.input(
                                     placeholder="Provide a path to save the registry config file",
@@ -741,7 +749,8 @@ def add_to_registry_config_file_dialog() -> rx.Component:
                                     default_value="points.csv",
                                     name="path",
                                     disabled=rx.cond(
-                                        BacnetScanState.selected_platform_uids.length() == 0, # & make new platform checkbox is false
+                                        (BacnetScanState.selected_platform_uids.length() == 0)
+                                        & (BacnetScanState.selected_platform_form.add_to_new_platform == False),
                                         True,
                                         False
                                     ),
@@ -780,7 +789,8 @@ def add_to_registry_config_file_dialog() -> rx.Component:
                             size="2",
                             type="submit",
                             disabled=rx.cond(
-                                BacnetScanState.selected_platform_uids.length() == 0, # & add to new platform checkbox == false
+                                (BacnetScanState.selected_platform_uids.length() == 0)
+                                & (BacnetScanState.selected_platform_form.add_to_new_platform == False),
                                 True,
                                 False
                             ),

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -1606,7 +1606,7 @@ class BacnetScanState(rx.State):
     dialog_registry_open: bool = False
     dialog_select_platform_open: bool = False
     dialog_confirm_add_platform_agent: bool = False
-    selected_platform_uid: str = ""
+    selected_platform_uids: list[str] = []
 
     # Fields
     proxy_field_value: str = ""
@@ -1625,7 +1625,7 @@ class BacnetScanState(rx.State):
     all_device_scan_point_status: list[BACnetDevicePointScanStatus] = []
 
 
-    _platform_has_platform_driver: bool = True
+    _platforms_have_platform_driver: list[str] = []
 
 
     # For bacnet point stuff
@@ -1709,11 +1709,8 @@ class BacnetScanState(rx.State):
 
     # Computed Vars
     @rx.var
-    def platform_has_platform_driver(self) -> bool:
-        if self.selected_platform_uid == "":
-            return True
-        return self._platform_has_platform_driver
-        
+    def platforms_with_platform_driver(self) -> list[str]:
+        return self._platforms_have_platform_driver
 
     # For point pagination
     @rx.var
@@ -2208,7 +2205,7 @@ class BacnetScanState(rx.State):
 
     @rx.event
     def close_dialogs(self):
-        self.selected_platform_uid = ""
+        self.selected_platform_uids = []
         self.dialog_registry_open = False
         self.dialog_select_platform_open = False
 
@@ -2707,32 +2704,42 @@ class BacnetScanState(rx.State):
     # Other
     @rx.event
     async def select_platform_for_registry_config(self, uid: str):
-        self.selected_platform_uid = uid if self.selected_platform_uid != uid else ""
+        """Toggle selection of a platform for registry config."""
 
+        # Toggle selection of the platform
+        if uid in self.selected_platform_uids:
+            self.selected_platform_uids.remove(uid)
+            if uid in self._platforms_have_platform_driver:
+                self._platforms_have_platform_driver.remove(uid)
+        else:
+            self.selected_platform_uids.append(uid)
+            
+        # Check if platform has platform.driver
         platform_state = await self.get_state(PlatformPageState)
         platform = platform_state.platforms.get(uid)
         if not platform:
-            self._platform_has_platform_driver = True
             return
-        
-        self._platform_has_platform_driver = "platform.driver" in platform.platform.agents
+            
+        if "platform.driver" in platform.platform.agents:
+            self._platforms_have_platform_driver.append(uid)
+        logger.debug(f"Selected platforms: {self.selected_platform_uids}")
+        logger.debug(f"Platforms with platform.drivers: {self._platforms_have_platform_driver}")
         return
 
     @rx.event
     def on_add_to_registry_config_confirm(self, form_data):
         """Handle the confirmation to add selected points to registry config."""
-        if self.selected_platform_uid == "":
-            # yield rx.toast.error("No platform selected for registry config.")
+        if not hasattr(self, "selected_platform_uids") or not self.selected_platform_uids:
+            logger.debug("No platforms selected for registry config. Or cancelled")
             return
+            
+        logger.debug(f"Selected platform UIDs: {self.selected_platform_uids}")
         
-        logger.debug(f"selected platform UID: {self.selected_platform_uid}")
-        platform_uid = self.selected_platform_uid
-
         path = form_data.get("path", "")
         if path == "":
             yield rx.toast.error("Path cannot be empty.")
             return
-
+            
         # Close any open dialogs
         yield BacnetScanState.close_dialogs()
         
@@ -2740,120 +2747,112 @@ class BacnetScanState(rx.State):
         csv_data = self._convert_selected_points_to_csv()
         escaped_csv_data = csv_data.replace("'", "\\'")
         
-        # Add the registry config to the platform
-        yield BacnetScanState.on_add_to_registry_config(platform_uid, path, escaped_csv_data)
+        # Add the registry config to each selected platform
+        for platform_uid in self.selected_platform_uids:
+            yield BacnetScanState.on_add_to_registry_config(platform_uid, path, escaped_csv_data)
 
-    # TODO move all the stuff handiling adding the actual config store entry to its designated state and method
     @rx.event
     async def on_add_to_registry_config(self, platform_uid: str, path: str, escaped_csv_data: str):
         """Add selected BACnet points to a platform.driver registry configuration."""
         # Close any open dialogs
         yield BacnetScanState.close_dialogs()
-                
         
-        # Step 1: Ensure platform.driver agent exists
-        # yield BacnetScanState.ensure_platform_driver_exists(platform_uid)
-        # we need tto shove the method in here to ensure that it runs one at a time...
         platform_page_state: PlatformPageState = await self.get_state(PlatformPageState)
         platform = platform_page_state.platforms.get(platform_uid)
+        
         if not platform:
             logger.debug(f"Platform with UID {platform_uid} not found.")
             logger.debug(f"Available platforms: {list(platform_page_state.platforms.keys())}")
-            yield rx.toast.error("Platform not found")
+            yield rx.toast.error(f"Platform {platform_uid} not found")
             return
         
-        # Find and add platform.driver agent
+        # Find and add platform.driver agent if it doesn't exist
         if "platform.driver" not in platform.platform.agents:
             for agent in platform_page_state.list_of_agents:
                 if agent.identity == "platform.driver":
                     yield PlatformPageState.handle_adding_agent(agent, platform_uid)
-        # ===============================================================
-
-        # Step 2: Add the registry config to the platform.driver agent
+                    break
+            else:
+                yield rx.toast.error(f"Could not add platform.driver agent to platform {platform_uid}")
+                return
+            
+        # Add the registry config to the platform.driver agent
         yield BacnetScanState.add_config_to_platform_driver(
-            platform_uid, 
+            platform_uid,
             escaped_csv_data,
             path
         )
 
     @rx.event
     async def ensure_platform_driver_exists(self, platform_uid: str):
-        """Make sure the platform has a platform.driver agent.
-        
-        Returns:
-            bool: True if platform.driver exists or was successfully added, False otherwise.
-        """
+        """Make sure the platform has a platform.driver agent."""
         platform_page_state: PlatformPageState = await self.get_state(PlatformPageState)
         platform = platform_page_state.platforms.get(platform_uid)
+        
         if not platform:
             return
-        
+            
         # Check if platform.driver already exists
         if "platform.driver" in platform.platform.agents:
-            return 
-        
+            return
+            
         # Find and add platform.driver agent
         for agent in platform_page_state.list_of_agents:
             if agent.identity == "platform.driver":
                 yield PlatformPageState.handle_adding_agent(agent, platform_uid)
-                # We need to check if the agent was actually added
-                return 
-        
+                return
+                
         # Couldn't find platform.driver in available agents
-        yield rx.toast.error("Could not add platform.driver agent")
-    
+        yield rx.toast.error(f"Could not add platform.driver agent to {platform_uid}")
+        return
+
     @rx.event
     async def add_config_to_platform_driver(
-        self, 
-        platform_uid: str, 
+        self,
+        platform_uid: str,
         csv_value: str,
         path: str
     ):
         """Add a config store entry with the CSV value to the platform.driver agent."""
         platform_page_state: PlatformPageState = await self.get_state(PlatformPageState)
         platform = platform_page_state.platforms.get(platform_uid)
-        if "platform.driver" not in platform.platform.agents:
-            yield rx.toast.error("Platform or platform.driver agent not found")
         
+        if not platform or "platform.driver" not in platform.platform.agents:
+            yield rx.toast.error(f"Platform {platform_uid} or platform.driver agent not found")
+            return
+            
         # Get the platform.driver agent
         driver_agent = platform.platform.agents.get("platform.driver", None)
         if driver_agent is None:
-            logger.debug(f"an error occurred, here are the list of agents on the platform: {platform.platform.agents.keys()}")
-            yield rx.toast.error("Platform.driver agent not found on platform")
+            logger.debug(f"An error occurred, here are the list of agents on the platform: {platform.platform.agents.keys()}")
+            yield rx.toast.error(f"Platform.driver agent not found on platform {platform_uid}")
             return
-
+            
         # Create and add the config store entry
         component_id = generate_unique_uid()
         config_entry = self._create_config_store_entry(path, csv_value, component_id)
-        driver_agent.config_store.append(config_entry)
         
-        # Save the config store entry
-
-        # NOTE: This is largely a copy and paste job from AgentConfigState.save_config_store_entry
-        # TODO: make the function referenced above more modular and not tied to AgentConfigState variables
+        # Check if path already exists in this platform's config
         list_of_config_paths: list[tuple[str, str]] = [
             (entry_.safe_entry["path"], entry_.component_id) for entry_ in driver_agent.config_store
         ]
-        # Check if the path exists and belongs to a different component
-        for path, component_id in list_of_config_paths:
-            if config_entry.path == "" or (config_entry.path == path and config_entry.component_id != component_id):
-                # This check catches all empty paths or duplicate paths
-                yield rx.toast.error(f"Config path is already in use.")
+        
+        for existing_path, existing_component_id in list_of_config_paths:
+            if config_entry.path == existing_path:
+                # This path already exists for this platform
+                yield rx.toast.error(f"Config path '{path}' already exists in platform {platform_uid}")
                 return
+                
+        # Add and save the config entry
+        driver_agent.config_store.append(config_entry)
         config_entry.safe_entry = config_entry.dict()
-        logger.debug(f"this is the config_entry's safe dict: {config_entry.safe_entry}")
-        config_entry.uncommitted=False
-        logger.debug(f"going through the agent's config store, here they are:")
-        for driver_agent_config in driver_agent.config_store:
-            logger.debug(f"safe dict: {driver_agent_config.safe_entry}")
-
+        config_entry.uncommitted = False
+        
         # Finalize and save the agent
         driver_agent.is_new = False
         driver_agent.safe_agent = driver_agent.to_dict()
         
-        # Update the platform state
-        # yield PlatformPageState.cement_registry_config(platform)
-        yield rx.toast.success("BACnet points added to registry")
+        yield rx.toast.success(f"BACnet points added to registry for platform {platform_uid}")
 
     # Exporting
     @rx.event

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -643,8 +643,8 @@ class PlatformPageState(rx.State):
         yield rx.toast.info("Changes Reverted.")
 
     @rx.event
-    async def generate_new_platform(self):
-        new_uid = self.generate_unique_uid()
+    def generate_new_platform(self, defined_uid: str = None):
+        new_uid = self.generate_unique_uid() if defined_uid is None else defined_uid
         new_host = HostEntryModelView(id="", ansible_user="", ansible_host="")
         new_platform = PlatformModelView(config=PlatformConfigModelView(), in_file=False)
         new_platform.safe_platform = new_platform.to_dict()
@@ -1623,7 +1623,7 @@ class BacnetScanState(rx.State):
     local_ip_info: LocalIPModel = LocalIPModel()
     windows_host_ip_info: WindowsHostIPModel = WindowsHostIPModel()
     all_device_scan_point_status: list[BACnetDevicePointScanStatus] = []
-
+    selected_platform_form: SelectedPlatformForm = SelectedPlatformForm()
 
     _platforms_have_platform_driver: list[str] = []
 
@@ -1717,8 +1717,7 @@ class BacnetScanState(rx.State):
         # Check if any selected platform lacks a driver
         for platform_uid in self.selected_platform_uids:
             # If platform not in our dictionary or its value is False
-            if (platform_uid not in self._platforms_have_platform_driver or 
-                not self._platforms_have_platform_driver[platform_uid]):
+            if platform_uid not in self._platforms_have_platform_driver:
                 return True
         
         # All selected platforms have drivers
@@ -2221,6 +2220,7 @@ class BacnetScanState(rx.State):
 
     @rx.event
     def close_dialogs(self):
+        self.selected_platform_form.add_to_new_platform = False
         self.selected_platform_uids = []
         self.dialog_registry_open = False
         self.dialog_select_platform_open = False
@@ -2741,11 +2741,15 @@ class BacnetScanState(rx.State):
         logger.debug(f"Selected platforms: {self.selected_platform_uids}")
         logger.debug(f"Platforms with platform.drivers: {self._platforms_have_platform_driver}")
         return
+    
+    @rx.event
+    def toggle_add_to_new_platform(self, value):
+        self.selected_platform_form.add_to_new_platform = value
 
     @rx.event
     def on_add_to_registry_config_confirm(self, form_data):
         """Handle the confirmation to add selected points to registry config."""
-        if not hasattr(self, "selected_platform_uids") or not self.selected_platform_uids:
+        if not hasattr(self, "selected_platform_uids") or not self.selected_platform_uids and self.selected_platform_form.add_to_new_platform == False:
             logger.debug("No platforms selected for registry config. Or cancelled")
             return
             
@@ -2766,6 +2770,15 @@ class BacnetScanState(rx.State):
         # Add the registry config to each selected platform
         for platform_uid in self.selected_platform_uids:
             yield BacnetScanState.on_add_to_registry_config(platform_uid, path, escaped_csv_data)
+
+        add_to_new_platform: bool = form_data.get("add_to_new_platform") == "on"
+
+        if add_to_new_platform:
+            generated_uid = generate_unique_uid()
+            yield rx.toast.info("Routing to the new platform...")
+            yield PlatformPageState.generate_new_platform(generated_uid)
+            yield BacnetScanState.on_add_to_registry_config(generated_uid, path, escaped_csv_data)
+            self.selected_platform_form.add_to_new_platform = False
 
     @rx.event
     async def on_add_to_registry_config(self, platform_uid: str, path: str, escaped_csv_data: str):

--- a/volttron_installer/state.py
+++ b/volttron_installer/state.py
@@ -1709,6 +1709,22 @@ class BacnetScanState(rx.State):
 
     # Computed Vars
     @rx.var
+    def display_selected_platforms_warning(self) -> bool:
+        """
+        Return True if any selected platform DOES NOT have a platform driver.
+        This warns users that some selected platforms need a driver to be added.
+        """
+        # Check if any selected platform lacks a driver
+        for platform_uid in self.selected_platform_uids:
+            # If platform not in our dictionary or its value is False
+            if (platform_uid not in self._platforms_have_platform_driver or 
+                not self._platforms_have_platform_driver[platform_uid]):
+                return True
+        
+        # All selected platforms have drivers
+        return False
+    
+    @rx.var
     def platforms_with_platform_driver(self) -> list[str]:
         return self._platforms_have_platform_driver
 


### PR DESCRIPTION
Allows for the selection of multiple platforms to apply the registry config file to. Added an "Add to new platform" checkbox and if selected, applies the registry config file to the newly added platform as well as routing the user to the new platform.


Closes #121 