### PR TITLE
Added two needed dependancies to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ pydantic
 pydantic-settings
 loguru
 aiofiles
+pyyaml
+rdflib
 -e git+https://github.com/riley206-pnnl/bacnet-scan-tool.git@feature/bacnet-tests#egg=bacnet_scan_tool


### PR DESCRIPTION
added two new dependencies. 
- pyyaml
- rdflib

These dependencies allow the bacnet-scan-tool to spin up properly, allowing new devs to setup the installer in their environment.

Closes #138